### PR TITLE
Django Toolbar config, tématické kolekce #532

### DIFF
--- a/Seeder/core/utils.py
+++ b/Seeder/core/utils.py
@@ -40,4 +40,10 @@ def dict_diff(first, second):
 
 
 def show_toolbar(request):
-    return not request.is_ajax() and not request.user.is_anonymous
+    """
+    Only show Django Toolbar for user "fasand" or "petr"
+    """
+    return (not request.is_ajax() and
+            not request.user.is_anonymous and
+            (request.user.username == "fasand"
+             or request.user.username == "petr"))

--- a/Seeder/www/templates/topic_collections/detail.html
+++ b/Seeder/www/templates/topic_collections/detail.html
@@ -50,7 +50,7 @@
                         {% if source.is_public %}
                         <h2><a href="{{ source.wayback_url }}" target="_blank">{{ source }}</a></h2>
                         {% else %}
-                        <h2 class="passive_link">{{ source }}</h2>
+                        <h2 class="passive_link"><a href="{{ source.wayback_url }}" target="_blank">{{ source }}</a></h2>
                         {% endif %}
                         <p>
                             <span class="italic">{{ source.stripped_main_url }}</span>
@@ -64,7 +64,7 @@
                 {% for source in custom_seeds %}
                 <div class="row">
                     <div class="col-md-12 item-textual">
-                        <h2 class="passive_link">{{ source.name }}</h2>
+                        <h2 class="passive_link"><a href="{{ source.wayback_url }}" target="_blank">{{ source.name }}</a></h2>
                         <p>
                             <span class="italic">{{ source.url }}</span>
                             <span class="blue">[</span><a href="{{ source.url }}"


### PR DESCRIPTION
- Fixes #532: wayback_url i na nearchivovanych zdrojich, jsou modře kurzívou
- Django Toolbar se zobrazí jen pro uživatele "fasand" (můj lokální) a "petr" (na testu)