### PR TITLE
Issues/1.0.7 (mainly #636)

### DIFF
--- a/Seeder/core/management/commands/generate_unique_seeds.py
+++ b/Seeder/core/management/commands/generate_unique_seeds.py
@@ -1,0 +1,36 @@
+import uuid
+from django.core.management.base import BaseCommand, CommandError
+
+class Command(BaseCommand):
+    help = 'Generate random URLs and append to a file'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--base-url', type=str, help=(
+                'Base URL, specify incl. http:// and without an ending slash. '
+                'E.g. "http://google.com"'
+            ), required=False)
+        parser.add_argument(
+            '-n', '--num', type=int, help='Number of seeds to generate',
+              required=True)
+        parser.add_argument(
+            '-o', '--output', type=str, help=(
+                'Output file path with reference to the Seeder/Seeder folder. '
+                'E.g. "testseeds.txt"'
+            ), required=True)
+
+    def handle(self, *args, **options):
+        base_url = (options['base_url'] if options['base_url']
+                    else f"http://{uuid.uuid4()}.com")
+        num = options['num']
+        output_file = options['output']
+
+        try:
+            with open(output_file, 'a') as f:
+                for i in range(num):
+                    f.write(f"{base_url}/{i}\n")
+        except IOError as e:
+            raise CommandError('Could not write to file') from e
+
+        self.stdout.write(self.style.SUCCESS(
+            f'Successfully generated {num} seeds to {output_file}'))

--- a/Seeder/harvests/models.py
+++ b/Seeder/harvests/models.py
@@ -12,6 +12,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.urls import reverse
 from django.dispatch import receiver
 from django.db.models.signals import pre_save
+from django.conf import settings
 
 from reversion import revisions
 from autoslug import AutoSlugField
@@ -764,6 +765,24 @@ class TopicCollection(HarvestAbstractModel):
             idCollection=self.pk,
             aggregationWithSameType=self.aggregation_with_same_type,
         )
+
+    def backup_custom_seeds(self):
+        """
+        Save all current custom seeds to a text file under media/seeds/backup
+        Filename: tc_{current datetime}_{TC id}_{15 chars of TC title}.txt
+        :return url: The media URL of the saved file
+        """
+        filename = (f"tc_{timezone.now():%Y-%m-%d_%H-%M}_{self.pk}_"
+                    f"{self.title[:15].replace(' ', '-')}.txt")
+        filepath = os.path.join(
+            settings.MEDIA_ROOT, settings.SEEDS_BACKUP_DIR, filename)
+        # Ensure folder exists
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        # Save seeds and return the media URL for download
+        with open(filepath, "w") as f:
+            f.write(self.custom_seeds)
+        return os.path.join(
+            settings.MEDIA_URL, settings.SEEDS_BACKUP_DIR, filename)
 
     def __str__(self):
         sign = '✔' if self.active else '✗'

--- a/Seeder/harvests/views.py
+++ b/Seeder/harvests/views.py
@@ -20,6 +20,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.generic.base import TemplateView
 from django.views.generic import DetailView, FormView, View
 from django.conf import settings
+from django.utils.safestring import mark_safe
 
 from core import generic_views
 from comments.views import CommentViewGeneric
@@ -475,19 +476,46 @@ class InternalCollectionEdit(InternalTCView, generic_views.EditView):
         return form_class(files, **self.get_form_kwargs())
 
     def form_valid(self, form):
-        topic = form.save()
-        topic.pair_custom_seeds()
-
+        topic = form.save(commit=False)
+        form.save_m2m()  # must save m2m when commit=False
+        # Create and delete attachments
         ids_to_delete = form.cleaned_data['files_to_delete']
         for att in models.Attachment.objects.filter(id__in=ids_to_delete):
             att.file.delete()
             att.delete()
-
         for each in form.cleaned_data["attachments"]:
             models.Attachment.objects.create(
-                file=each,
-                topic_collection=topic
-            )
+                file=each, topic_collection=topic)
+        # If a custom seeds file is uploaded, backup and replace TC.custom_seeds
+        new_custom_seeds = form.cleaned_data.get("custom_seeds_file")
+        if new_custom_seeds:
+            url = topic.backup_custom_seeds()
+            try:
+                topic.custom_seeds = new_custom_seeds.read().decode("utf-8")
+                topic.save()  # full save, including new large custom seeds
+            except UnicodeDecodeError:
+                messages.error(self.request, _("Cannot decode file to UTF-8"))
+            messages.success(self.request, mark_safe(_(
+                "Original custom_seeds have been backed to: <a href='%(url)s' "
+                "target='_blank'>%(url)s</a>"
+            ) % {"url": url}))
+            messages.warning(self.request, _(
+                "Uploaded custom seeds will not be paired automatically"))
+        else:
+            # Small edits shouldn't touch custom_seeds because it'll never load
+            if form.custom_seeds_too_large:
+                topic.save(update_fields=(
+                    set(form.fields.keys()) - set([
+                        "custom_seeds", "custom_sources", "attachments",
+                        "files_to_delete", "custom_seeds_file",
+                    ])
+                ))
+            # Only pair custom seeds if there aren't too many of them and they
+            # haven't just been imported
+            else:
+                topic.save()  # full save, not many custom seeds
+                topic.pair_custom_seeds()
+
         return HttpResponseRedirect(topic.get_absolute_url())
 
 

--- a/Seeder/locale/cs/LC_MESSAGES/django.po
+++ b/Seeder/locale/cs/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Seeder\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-04 07:53+0000\n"
+"POT-Creation-Date: 2023-07-24 10:40+0000\n"
 "PO-Revision-Date: 2018-04-16 13:40+0200\n"
 "Last-Translator: mariehaskovcova <marie.haskovcova@nkp.cz>, 2017\n"
 "Language-Team: Czech (https://www.transifex.com/webarchivecz/teams/43032/"
@@ -151,7 +151,7 @@ msgid "This comment has been removed"
 msgstr "Komentář byl odstraněn"
 
 #: comments/models.py:168 qa/models.py:40 qa/templates/detail.html:30
-#: source/models.py:254 source/models.py:509 source/templates/source.html:83
+#: source/models.py:254 source/models.py:534 source/templates/source.html:83
 #: templates/history.html:14
 msgid "Comment"
 msgstr "Komentář"
@@ -215,7 +215,7 @@ msgid "Narodni knihovna CR - archivace Vasich webovych stranek"
 msgstr "Narodni knihovna CR - archivace Vasich webovych stranek"
 
 #: contracts/models.py:55 contracts/templates/contract.html:21
-#: harvests/models.py:232 harvests/models.py:710 source/models.py:268
+#: harvests/models.py:233 harvests/models.py:711 source/models.py:268
 #: voting/models.py:27
 msgid "State"
 msgstr "Stav"
@@ -522,15 +522,33 @@ msgstr "dataLimit nesmí být přes 1TB"
 msgid "One URL per line"
 msgstr "Jedna URL na řádku"
 
-#: harvests/models.py:49
+#: harvests/forms.py:204
+msgid ""
+"Provide a text file with one seed per line which will overwrite all "
+"custom_seeds. The original custom_seeds will be backed up to the media/seeds/"
+"backup folder."
+msgstr ""
+"Přiložte textový soubor s jedním semínkem na řádek, který přepíše všechna "
+"mimosystémová semínka. Původní semínka budou zálohována do media/seeds/"
+"backup složky."
+
+#: harvests/forms.py:225
+msgid ""
+"Custom seeds field is disabled because there are too many seeds to be "
+"displayed in an HTML text field."
+msgstr ""
+"Pole mimosystémových semínek je nyní schováno jelikož kolekce má příliš mnoho "
+"semínek pro zobrazení v HTML textovém poli."
+
+#: harvests/models.py:50
 msgid "Included sources"
 msgstr "Přiřazené zdroje"
 
-#: harvests/models.py:54
+#: harvests/models.py:55
 msgid "Custom seeds URL"
 msgstr "Mimosystémová semínka"
 
-#: harvests/models.py:55
+#: harvests/models.py:56
 msgid ""
 "Sem vložte všechna semínka, po uložení zde zůstanou zdroje bez záznamu v "
 "Seederu, ostatní budu v poli Přiřazené zdroje"
@@ -538,198 +556,198 @@ msgstr ""
 "Sem vložte všechna semínka, po uložení zde zůstanou zdroje bez záznamu v "
 "Seederu, ostatní budu v poli Přiřazené zdroje"
 
-#: harvests/models.py:204
+#: harvests/models.py:205
 msgid "Planned"
 msgstr "Plánované"
 
-#: harvests/models.py:205
+#: harvests/models.py:206
 msgid "Ready to harvest"
 msgstr "Připraveno na sklízení"
 
-#: harvests/models.py:206 harvests/models.py:687
+#: harvests/models.py:207 harvests/models.py:688
 msgid "Running"
 msgstr "Probíhající"
 
-#: harvests/models.py:207
+#: harvests/models.py:208
 msgid "Success"
 msgstr "Úspěšné"
 
-#: harvests/models.py:208
+#: harvests/models.py:209
 msgid "Success with failures"
 msgstr "Úspěšné se závadami"
 
-#: harvests/models.py:209
+#: harvests/models.py:210
 msgid "Cancelled"
 msgstr "Zrušené"
 
-#: harvests/models.py:210
+#: harvests/models.py:211
 msgid "Failed"
 msgstr "Neúspěšné"
 
-#: harvests/models.py:234 harvests/models.py:801
+#: harvests/models.py:235 harvests/models.py:820
 #: harvests/templates/harvest.html:19 harvests/templates/harvest_config.html:18
 msgid "Harvest type"
 msgstr "Typ sklizně"
 
-#: harvests/models.py:236 harvests/models.py:596 harvests/models.py:714
+#: harvests/models.py:237 harvests/models.py:597 harvests/models.py:715
 #: harvests/tables.py:76 harvests/tables.py:93 www/tables.py:13
 msgid "title"
 msgstr "Název"
 
-#: harvests/models.py:238 harvests/templates/harvest.html:17
+#: harvests/models.py:239 harvests/templates/harvest.html:17
 #: source/models.py:255 source/templates/source.html:87
 msgid "Annotation"
 msgstr "Anotace"
 
-#: harvests/models.py:240 harvests/models.py:729
+#: harvests/models.py:241 harvests/models.py:730
 msgid "Date of harvest"
 msgstr "Datum sklizně"
 
-#: harvests/models.py:242
+#: harvests/models.py:243
 msgid "Seeds by frequency"
 msgstr "Semínka podle frekvence"
 
-#: harvests/models.py:254 harvests/templates/harvest.html:27
+#: harvests/models.py:255 harvests/templates/harvest.html:27
 msgid "Date frozen"
 msgstr "Datum zmrazení"
 
-#: harvests/models.py:259
+#: harvests/models.py:260
 msgid "Topic collections"
 msgstr "Tematické kolekce"
 
-#: harvests/models.py:264 harvests/templates/harvest.html:58
+#: harvests/models.py:265 harvests/templates/harvest.html:58
 msgid "Topic collections by frequency"
 msgstr "Tematické kolekce podle frekvence"
 
-#: harvests/models.py:272 harvests/templates/harvest.html:37
+#: harvests/models.py:273 harvests/templates/harvest.html:37
 msgid "Paraharvest"
 msgstr "Parasklizeň"
 
-#: harvests/models.py:275 harvests/templates/harvest.html:39
+#: harvests/models.py:276 harvests/templates/harvest.html:39
 msgid "Manuals"
 msgstr "Manuals"
 
-#: harvests/models.py:277 harvests/templates/harvest.html:51
+#: harvests/models.py:278 harvests/templates/harvest.html:51
 msgid "Combined"
 msgstr "Combined"
 
-#: harvests/models.py:279 harvests/views.py:382
+#: harvests/models.py:280 harvests/views.py:383
 msgid "ArchiveIt"
 msgstr "ArchiveIt"
 
-#: harvests/models.py:282 harvests/views.py:384
+#: harvests/models.py:283 harvests/views.py:385
 msgid "Tests"
 msgstr "Tests"
 
-#: harvests/models.py:286 harvests/models.py:803
+#: harvests/models.py:287 harvests/models.py:822
 #: harvests/templates/harvest.html:65 harvests/templates/harvest_config.html:20
 msgid "duration"
 msgstr "duration"
 
-#: harvests/models.py:288 harvests/models.py:805
+#: harvests/models.py:289 harvests/models.py:824
 #: harvests/templates/harvest.html:67 harvests/templates/harvest_config.html:22
 msgid "budget"
 msgstr "budget"
 
-#: harvests/models.py:290 harvests/models.py:807
+#: harvests/models.py:291 harvests/models.py:826
 #: harvests/templates/harvest.html:69 harvests/templates/harvest_config.html:24
 msgid "dataLimit"
 msgstr "dataLimit"
 
-#: harvests/models.py:292 harvests/models.py:809
+#: harvests/models.py:293 harvests/models.py:828
 #: harvests/templates/harvest.html:71 harvests/templates/harvest_config.html:26
 msgid "documentLimit"
 msgstr "documentLimit"
 
-#: harvests/models.py:294 harvests/models.py:811
+#: harvests/models.py:295 harvests/models.py:830
 #: harvests/templates/harvest.html:73 harvests/templates/harvest_config.html:28
 msgid "deduplication"
 msgstr "deduplication"
 
-#: harvests/models.py:298 harvests/templates/harvest.html:82
+#: harvests/models.py:299 harvests/templates/harvest.html:82
 msgid "Seeds not harvested"
 msgstr "Nesklizená semínka"
 
-#: harvests/models.py:600 harvests/models.py:717 source/constants.py:124
+#: harvests/models.py:601 harvests/models.py:718 source/constants.py:124
 #: source/models.py:239
 msgid "Curator"
 msgstr "Kurátor"
 
-#: harvests/models.py:604 source/templates/source.html:91
+#: harvests/models.py:605 source/templates/source.html:91
 msgid "keywords"
 msgstr "Klíčová slova"
 
-#: harvests/models.py:607 harvests/models.py:734
+#: harvests/models.py:608 harvests/models.py:735
 msgid "annotation"
 msgstr "anotace"
 
-#: harvests/models.py:611
+#: harvests/models.py:612
 msgid "image"
 msgstr "obrázek"
 
-#: harvests/models.py:670 harvests/templates/topic_collection.html:13
+#: harvests/models.py:671 harvests/templates/topic_collection.html:13
 msgid "External Topic Collection"
 msgstr "Externí tematická kolekce"
 
-#: harvests/models.py:671 templates/base.html:110
+#: harvests/models.py:672 templates/base.html:110
 msgid "External Topic Collections"
 msgstr "Externí tematické kolekce"
 
-#: harvests/models.py:688
+#: harvests/models.py:689
 msgid "New"
 msgstr "Aktualita"
 
-#: harvests/models.py:689
+#: harvests/models.py:690
 msgid "Finished"
 msgstr "Hotovo"
 
-#: harvests/models.py:701 harvests/templates/topic_collection.html:49
+#: harvests/models.py:702 harvests/templates/topic_collection.html:49
 #: source/models.py:274 source/templates/source.html:56 templates/api.html:17
 msgid "Frequency"
 msgstr "Frekvence"
 
-#: harvests/models.py:738
+#: harvests/models.py:739
 msgid "All sources are under open license or contract"
 msgstr "Všechny zdroje jsou nasmlouvány nebo vystaveny pod otevřenou licencí"
 
-#: harvests/models.py:741
+#: harvests/models.py:742
 msgid "Date from"
 msgstr "Od"
 
-#: harvests/models.py:742
+#: harvests/models.py:743
 msgid "Date to"
 msgstr "Do"
 
-#: harvests/models.py:746 harvests/templates/topic_collection.html:24
+#: harvests/models.py:747 harvests/templates/topic_collection.html:24
 msgid "Collection alias"
 msgstr "Alias kolekce"
 
-#: harvests/models.py:748 harvests/templates/topic_collection.html:82
+#: harvests/models.py:749 harvests/templates/topic_collection.html:82
 msgid "Aggregation with same type"
 msgstr "Agregovat se stejným typem"
 
-#: harvests/models.py:773
+#: harvests/models.py:792
 msgid "Internal Topic Collection"
 msgstr "Interní tematická kolekce"
 
-#: harvests/models.py:774 harvests/templates/external_topic_collection.html:82
+#: harvests/models.py:793 harvests/templates/external_topic_collection.html:82
 #: templates/base.html:113
 msgid "Internal Topic Collections"
 msgstr "Interní tematické kolekce"
 
-#: harvests/models.py:780
+#: harvests/models.py:799
 msgid "file"
 msgstr "pole"
 
-#: harvests/models.py:814
+#: harvests/models.py:833
 msgid "Harvest Configuration"
 msgstr "Konfigurace sklizní"
 
-#: harvests/models.py:815 harvests/views.py:397 templates/base.html:127
+#: harvests/models.py:834 harvests/views.py:398 templates/base.html:127
 msgid "Harvest Configurations"
 msgstr "Konfigurace sklizní"
 
-#: harvests/models.py:819
+#: harvests/models.py:838
 #, python-format
 msgid "Configuration for %(type)s Harvests"
 msgstr "Konfigurace pro %(type)s Sklizně"
@@ -924,61 +942,78 @@ msgid "All sources are open?"
 msgstr "Všechny zdroje jsou otevřené?"
 
 #: harvests/templates/topic_collection.html:94 qa/templates/qa_form.html:20
-#: source/models.py:538 source/templates/source.html:152
+#: source/models.py:563 source/templates/source.html:152
 msgid "Seeds"
 msgstr "Semínka"
 
-#: harvests/views.py:57 templates/base.html:122
+#: harvests/views.py:58 templates/base.html:122
 msgid "Harvests"
 msgstr "Sklizně"
 
-#: harvests/views.py:112 harvests/views.py:130
+#: harvests/views.py:113 harvests/views.py:131
 msgid "Harvest contains no seeds!"
 msgstr ""
 "Sklizeň neobsahuje žádná semínka! Tím pádem nemůže být zmrazena (stav "
 "nastaven na 'Připraveno na sklízení')"
 
-#: harvests/views.py:352 harvests/views.py:371
+#: harvests/views.py:353 harvests/views.py:372
 msgid "Available URLs for date"
 msgstr "Seznam URL pro datum"
 
-#: harvests/views.py:356
+#: harvests/views.py:357
 msgid "All seeds for Harvest"
 msgstr "Všechna semínka pro sklizeň"
 
-#: harvests/views.py:383
+#: harvests/views.py:384
 msgid "VNC"
 msgstr "VNC: Výběrové custom"
 
-#: harvests/views.py:385
+#: harvests/views.py:386
 msgid "Totals"
 msgstr "Totals: Všechna semínka"
 
-#: harvests/views.py:444
+#: harvests/views.py:445
 msgid "TopicCollections"
 msgstr "Tematické kolekce"
 
-#: harvests/views.py:454
+#: harvests/views.py:455
 msgid "Add TopicCollection"
 msgstr "Přidat tematickou kolekci"
 
-#: harvests/views.py:530
+#: harvests/views.py:497
+msgid "Cannot decode file to UTF-8"
+msgstr "Nelze dekódovat soubor do UTF-8"
+
+#: harvests/views.py:499
+#, python-format
+msgid ""
+"Original custom_seeds have been backed to: <a href='%(url)s' target='_blank'>"
+"%(url)s</a>"
+msgstr ""
+"Původní mimosystémová semínka byla zálohována do "
+"<a href='%(url)s' target='_blank'>%(url)s</a>"
+
+#: harvests/views.py:503
+msgid "Uploaded custom seeds will not be paired automatically"
+msgstr "Nahraná mimosystémová semínka nebudou automaticky párována"
+
+#: harvests/views.py:558
 msgid "ExternalTopicCollections"
 msgstr "Externí tematické kolekce"
 
-#: harvests/views.py:540
+#: harvests/views.py:568
 msgid "Add ExternalTopicCollection"
 msgstr "Přidat Externí tematickou kolekci"
 
-#: harvests/views.py:624
+#: harvests/views.py:652
 msgid "Topic collection published"
 msgstr "Tematická kolekce publikována"
 
-#: harvests/views.py:626
+#: harvests/views.py:654
 msgid "Topic collection unpublished"
 msgstr "Tematická kolekce nepublikována"
 
-#: harvests/views.py:640
+#: harvests/views.py:668
 msgid "URL slug successfully updated"
 msgstr "URL byla úspěšné změněna"
 
@@ -1262,63 +1297,63 @@ msgstr "Podkategorie"
 msgid "Source is dead"
 msgstr "Mrtvý web"
 
-#: source/models.py:490
+#: source/models.py:515
 msgid "default"
 msgstr "výchozí"
 
-#: source/models.py:491
+#: source/models.py:516
 msgid "low"
 msgstr "low"
 
-#: source/models.py:492
+#: source/models.py:517
 msgid "very_low"
 msgstr "very low"
 
-#: source/models.py:503
+#: source/models.py:528
 msgid "Main seed"
 msgstr "Hlavní semínko"
 
-#: source/models.py:504
+#: source/models.py:529
 msgid "Seed url"
 msgstr "URL semínko"
 
-#: source/models.py:510
+#: source/models.py:535
 msgid "From"
 msgstr "Od"
 
-#: source/models.py:511
+#: source/models.py:536
 msgid "To"
 msgstr "Do"
 
-#: source/models.py:514
+#: source/models.py:539
 msgid "Javascript"
 msgstr "Javascript"
 
-#: source/models.py:515
+#: source/models.py:540
 msgid "Global reject"
 msgstr "Odmítnuto"
 
-#: source/models.py:516
+#: source/models.py:541
 msgid "Youtube"
 msgstr "Youtube"
 
-#: source/models.py:517
+#: source/models.py:542
 msgid "Calendars"
 msgstr "Kalendáře"
 
-#: source/models.py:518
+#: source/models.py:543
 msgid "Local traps"
 msgstr "Local traps"
 
-#: source/models.py:519
+#: source/models.py:544
 msgid "Redirect on seed"
 msgstr "Přesměrováno na semínko"
 
-#: source/models.py:520
+#: source/models.py:545
 msgid "Robots.txt active"
 msgstr "aktivní Robots.txt"
 
-#: source/models.py:537
+#: source/models.py:562
 msgid "Seed"
 msgstr "Semínko"
 

--- a/Seeder/locale/en_US/LC_MESSAGES/django.po
+++ b/Seeder/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Seeder\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-04 07:53+0000\n"
+"POT-Creation-Date: 2023-07-24 10:40+0000\n"
 "PO-Revision-Date: 2017-11-07 12:38+0100\n"
 "Last-Translator: Visgean Skeloru <visgean@gmail.com>, 2017\n"
 "Language-Team: English (United States) (https://www.transifex.com/"
@@ -152,7 +152,7 @@ msgid "This comment has been removed"
 msgstr "This comment has been removed"
 
 #: comments/models.py:168 qa/models.py:40 qa/templates/detail.html:30
-#: source/models.py:254 source/models.py:509 source/templates/source.html:83
+#: source/models.py:254 source/models.py:534 source/templates/source.html:83
 #: templates/history.html:14
 msgid "Comment"
 msgstr "Comment"
@@ -216,7 +216,7 @@ msgid "Narodni knihovna CR - archivace Vasich webovych stranek"
 msgstr "National library of the CR - archiving your web sites"
 
 #: contracts/models.py:55 contracts/templates/contract.html:21
-#: harvests/models.py:232 harvests/models.py:710 source/models.py:268
+#: harvests/models.py:233 harvests/models.py:711 source/models.py:268
 #: voting/models.py:27
 msgid "State"
 msgstr "State"
@@ -525,15 +525,33 @@ msgstr "dataLimit cannot be over 1TB"
 msgid "One URL per line"
 msgstr "One URL per line"
 
-#: harvests/models.py:49
+#: harvests/forms.py:204
+msgid ""
+"Provide a text file with one seed per line which will overwrite all "
+"custom_seeds. The original custom_seeds will be backed up to the media/seeds/"
+"backup folder."
+msgstr ""
+"Provide a text file with one seed per line which will overwrite all "
+"custom_seeds. The original custom_seeds will be backed up to the media/seeds/"
+"backup folder."
+
+#: harvests/forms.py:225
+msgid ""
+"Custom seeds field is disabled because there are too many seeds to be "
+"displayed in an HTML text field."
+msgstr ""
+"Custom seeds field is disabled because there are too many seeds to be "
+"displayed in an HTML text field."
+
+#: harvests/models.py:50
 msgid "Included sources"
 msgstr "Included sources"
 
-#: harvests/models.py:54
+#: harvests/models.py:55
 msgid "Custom seeds URL"
 msgstr "Custom seeds URL"
 
-#: harvests/models.py:55
+#: harvests/models.py:56
 msgid ""
 "Sem vložte všechna semínka, po uložení zde zůstanou zdroje bez záznamu v "
 "Seederu, ostatní budu v poli Přiřazené zdroje"
@@ -541,198 +559,198 @@ msgstr ""
 "Enter all your seeds here. After saving, unknown sources will stay here, "
 "while the rest will be assigned to Custom sources"
 
-#: harvests/models.py:204
+#: harvests/models.py:205
 msgid "Planned"
 msgstr "Planned"
 
-#: harvests/models.py:205
+#: harvests/models.py:206
 msgid "Ready to harvest"
 msgstr "Ready to harvest"
 
-#: harvests/models.py:206 harvests/models.py:687
+#: harvests/models.py:207 harvests/models.py:688
 msgid "Running"
 msgstr "Running"
 
-#: harvests/models.py:207
+#: harvests/models.py:208
 msgid "Success"
 msgstr "Success"
 
-#: harvests/models.py:208
+#: harvests/models.py:209
 msgid "Success with failures"
 msgstr "Success with failures"
 
-#: harvests/models.py:209
+#: harvests/models.py:210
 msgid "Cancelled"
 msgstr "Cancelled"
 
-#: harvests/models.py:210
+#: harvests/models.py:211
 msgid "Failed"
 msgstr "Failed"
 
-#: harvests/models.py:234 harvests/models.py:801
+#: harvests/models.py:235 harvests/models.py:820
 #: harvests/templates/harvest.html:19 harvests/templates/harvest_config.html:18
 msgid "Harvest type"
 msgstr "Harvest type"
 
-#: harvests/models.py:236 harvests/models.py:596 harvests/models.py:714
+#: harvests/models.py:237 harvests/models.py:597 harvests/models.py:715
 #: harvests/tables.py:76 harvests/tables.py:93 www/tables.py:13
 msgid "title"
 msgstr "Title"
 
-#: harvests/models.py:238 harvests/templates/harvest.html:17
+#: harvests/models.py:239 harvests/templates/harvest.html:17
 #: source/models.py:255 source/templates/source.html:87
 msgid "Annotation"
 msgstr "Annotation"
 
-#: harvests/models.py:240 harvests/models.py:729
+#: harvests/models.py:241 harvests/models.py:730
 msgid "Date of harvest"
 msgstr "Date of harvest"
 
-#: harvests/models.py:242
+#: harvests/models.py:243
 msgid "Seeds by frequency"
 msgstr "Seeds by frequency"
 
-#: harvests/models.py:254 harvests/templates/harvest.html:27
+#: harvests/models.py:255 harvests/templates/harvest.html:27
 msgid "Date frozen"
 msgstr "Date frozen"
 
-#: harvests/models.py:259
+#: harvests/models.py:260
 msgid "Topic collections"
 msgstr "Topic collections"
 
-#: harvests/models.py:264 harvests/templates/harvest.html:58
+#: harvests/models.py:265 harvests/templates/harvest.html:58
 msgid "Topic collections by frequency"
 msgstr "Topic collections by frequency"
 
-#: harvests/models.py:272 harvests/templates/harvest.html:37
+#: harvests/models.py:273 harvests/templates/harvest.html:37
 msgid "Paraharvest"
 msgstr "Paraharvest"
 
-#: harvests/models.py:275 harvests/templates/harvest.html:39
+#: harvests/models.py:276 harvests/templates/harvest.html:39
 msgid "Manuals"
 msgstr "Manuals"
 
-#: harvests/models.py:277 harvests/templates/harvest.html:51
+#: harvests/models.py:278 harvests/templates/harvest.html:51
 msgid "Combined"
 msgstr "Combined"
 
-#: harvests/models.py:279 harvests/views.py:382
+#: harvests/models.py:280 harvests/views.py:383
 msgid "ArchiveIt"
 msgstr "ArchiveIt"
 
-#: harvests/models.py:282 harvests/views.py:384
+#: harvests/models.py:283 harvests/views.py:385
 msgid "Tests"
 msgstr "Tests"
 
-#: harvests/models.py:286 harvests/models.py:803
+#: harvests/models.py:287 harvests/models.py:822
 #: harvests/templates/harvest.html:65 harvests/templates/harvest_config.html:20
 msgid "duration"
 msgstr "duration"
 
-#: harvests/models.py:288 harvests/models.py:805
+#: harvests/models.py:289 harvests/models.py:824
 #: harvests/templates/harvest.html:67 harvests/templates/harvest_config.html:22
 msgid "budget"
 msgstr "budget"
 
-#: harvests/models.py:290 harvests/models.py:807
+#: harvests/models.py:291 harvests/models.py:826
 #: harvests/templates/harvest.html:69 harvests/templates/harvest_config.html:24
 msgid "dataLimit"
 msgstr "dataLimit"
 
-#: harvests/models.py:292 harvests/models.py:809
+#: harvests/models.py:293 harvests/models.py:828
 #: harvests/templates/harvest.html:71 harvests/templates/harvest_config.html:26
 msgid "documentLimit"
 msgstr "documentLimit"
 
-#: harvests/models.py:294 harvests/models.py:811
+#: harvests/models.py:295 harvests/models.py:830
 #: harvests/templates/harvest.html:73 harvests/templates/harvest_config.html:28
 msgid "deduplication"
 msgstr "deduplication"
 
-#: harvests/models.py:298 harvests/templates/harvest.html:82
+#: harvests/models.py:299 harvests/templates/harvest.html:82
 msgid "Seeds not harvested"
 msgstr "Seeds not harvested"
 
-#: harvests/models.py:600 harvests/models.py:717 source/constants.py:124
+#: harvests/models.py:601 harvests/models.py:718 source/constants.py:124
 #: source/models.py:239
 msgid "Curator"
 msgstr "Curator"
 
-#: harvests/models.py:604 source/templates/source.html:91
+#: harvests/models.py:605 source/templates/source.html:91
 msgid "keywords"
 msgstr "Keywords"
 
-#: harvests/models.py:607 harvests/models.py:734
+#: harvests/models.py:608 harvests/models.py:735
 msgid "annotation"
 msgstr "annotation"
 
-#: harvests/models.py:611
+#: harvests/models.py:612
 msgid "image"
 msgstr "image"
 
-#: harvests/models.py:670 harvests/templates/topic_collection.html:13
+#: harvests/models.py:671 harvests/templates/topic_collection.html:13
 msgid "External Topic Collection"
 msgstr "External Topic Collection"
 
-#: harvests/models.py:671 templates/base.html:110
+#: harvests/models.py:672 templates/base.html:110
 msgid "External Topic Collections"
 msgstr "External Topic Collections"
 
-#: harvests/models.py:688
+#: harvests/models.py:689
 msgid "New"
 msgstr "New"
 
-#: harvests/models.py:689
+#: harvests/models.py:690
 msgid "Finished"
 msgstr "Finished"
 
-#: harvests/models.py:701 harvests/templates/topic_collection.html:49
+#: harvests/models.py:702 harvests/templates/topic_collection.html:49
 #: source/models.py:274 source/templates/source.html:56 templates/api.html:17
 msgid "Frequency"
 msgstr "Frequency"
 
-#: harvests/models.py:738
+#: harvests/models.py:739
 msgid "All sources are under open license or contract"
 msgstr "All sources are under open license or contract"
 
-#: harvests/models.py:741
+#: harvests/models.py:742
 msgid "Date from"
 msgstr "Date from"
 
-#: harvests/models.py:742
+#: harvests/models.py:743
 msgid "Date to"
 msgstr "Date to"
 
-#: harvests/models.py:746 harvests/templates/topic_collection.html:24
+#: harvests/models.py:747 harvests/templates/topic_collection.html:24
 msgid "Collection alias"
 msgstr "Collection alias"
 
-#: harvests/models.py:748 harvests/templates/topic_collection.html:82
+#: harvests/models.py:749 harvests/templates/topic_collection.html:82
 msgid "Aggregation with same type"
 msgstr "Aggregation with same type"
 
-#: harvests/models.py:773
+#: harvests/models.py:792
 msgid "Internal Topic Collection"
 msgstr "Internal Topic Collection"
 
-#: harvests/models.py:774 harvests/templates/external_topic_collection.html:82
+#: harvests/models.py:793 harvests/templates/external_topic_collection.html:82
 #: templates/base.html:113
 msgid "Internal Topic Collections"
 msgstr "Internal Topic Collections"
 
-#: harvests/models.py:780
+#: harvests/models.py:799
 msgid "file"
 msgstr "file"
 
-#: harvests/models.py:814
+#: harvests/models.py:833
 msgid "Harvest Configuration"
 msgstr "Harvest Configuration"
 
-#: harvests/models.py:815 harvests/views.py:397 templates/base.html:127
+#: harvests/models.py:834 harvests/views.py:398 templates/base.html:127
 msgid "Harvest Configurations"
 msgstr "Harvest Configurations"
 
-#: harvests/models.py:819
+#: harvests/models.py:838
 #, python-format
 msgid "Configuration for %(type)s Harvests"
 msgstr "Configuration for %(type)s Harvests"
@@ -927,61 +945,78 @@ msgid "All sources are open?"
 msgstr "All sources are open?"
 
 #: harvests/templates/topic_collection.html:94 qa/templates/qa_form.html:20
-#: source/models.py:538 source/templates/source.html:152
+#: source/models.py:563 source/templates/source.html:152
 msgid "Seeds"
 msgstr "Seeds"
 
-#: harvests/views.py:57 templates/base.html:122
+#: harvests/views.py:58 templates/base.html:122
 msgid "Harvests"
 msgstr "Harvests"
 
-#: harvests/views.py:112 harvests/views.py:130
+#: harvests/views.py:113 harvests/views.py:131
 msgid "Harvest contains no seeds!"
 msgstr ""
 "Harvest contains no seeds! This means it cannot be frozen (set as 'Ready to "
 "harvest')"
 
-#: harvests/views.py:352 harvests/views.py:371
+#: harvests/views.py:353 harvests/views.py:372
 msgid "Available URLs for date"
 msgstr "Available URLs for date"
 
-#: harvests/views.py:356
+#: harvests/views.py:357
 msgid "All seeds for Harvest"
 msgstr "All seeds for Harvest"
 
-#: harvests/views.py:383
+#: harvests/views.py:384
 msgid "VNC"
 msgstr "VNC: Custom seeds"
 
-#: harvests/views.py:385
+#: harvests/views.py:386
 msgid "Totals"
 msgstr "Totals: All seeds"
 
-#: harvests/views.py:444
+#: harvests/views.py:445
 msgid "TopicCollections"
 msgstr "Topic Collections"
 
-#: harvests/views.py:454
+#: harvests/views.py:455
 msgid "Add TopicCollection"
 msgstr "Add Topic Collection"
 
-#: harvests/views.py:530
+#: harvests/views.py:497
+msgid "Cannot decode file to UTF-8"
+msgstr "Cannot decode file to UTF-8"
+
+#: harvests/views.py:499
+#, python-format
+msgid ""
+"Original custom_seeds have been backed to: <a href='%(url)s' target='_blank'>"
+"%(url)s</a>"
+msgstr ""
+"Original custom_seeds have been backed to: <a href='%(url)s' target='_blank'>"
+"%(url)s</a>"
+
+#: harvests/views.py:503
+msgid "Uploaded custom seeds will not be paired automatically"
+msgstr "Uploaded custom seeds will not be paired automatically"
+
+#: harvests/views.py:558
 msgid "ExternalTopicCollections"
 msgstr "External Topic Collections"
 
-#: harvests/views.py:540
+#: harvests/views.py:568
 msgid "Add ExternalTopicCollection"
 msgstr "Add External Topic Collection"
 
-#: harvests/views.py:624
+#: harvests/views.py:652
 msgid "Topic collection published"
 msgstr "Topic collection published"
 
-#: harvests/views.py:626
+#: harvests/views.py:654
 msgid "Topic collection unpublished"
 msgstr "Topic collection unpublished"
 
-#: harvests/views.py:640
+#: harvests/views.py:668
 msgid "URL slug successfully updated"
 msgstr "URL slug successfully updated"
 
@@ -1265,63 +1300,63 @@ msgstr "Sub category"
 msgid "Source is dead"
 msgstr "Source is dead"
 
-#: source/models.py:490
+#: source/models.py:515
 msgid "default"
 msgstr "default"
 
-#: source/models.py:491
+#: source/models.py:516
 msgid "low"
 msgstr "low"
 
-#: source/models.py:492
+#: source/models.py:517
 msgid "very_low"
 msgstr "very_low"
 
-#: source/models.py:503
+#: source/models.py:528
 msgid "Main seed"
 msgstr "Main seed"
 
-#: source/models.py:504
+#: source/models.py:529
 msgid "Seed url"
 msgstr "Seed URL"
 
-#: source/models.py:510
+#: source/models.py:535
 msgid "From"
 msgstr "From"
 
-#: source/models.py:511
+#: source/models.py:536
 msgid "To"
 msgstr "To"
 
-#: source/models.py:514
+#: source/models.py:539
 msgid "Javascript"
 msgstr "Javascript"
 
-#: source/models.py:515
+#: source/models.py:540
 msgid "Global reject"
 msgstr "Global reject"
 
-#: source/models.py:516
+#: source/models.py:541
 msgid "Youtube"
 msgstr "YouTube"
 
-#: source/models.py:517
+#: source/models.py:542
 msgid "Calendars"
 msgstr "Calendars"
 
-#: source/models.py:518
+#: source/models.py:543
 msgid "Local traps"
 msgstr "Local traps"
 
-#: source/models.py:519
+#: source/models.py:544
 msgid "Redirect on seed"
 msgstr "Redirect on seed"
 
-#: source/models.py:520
+#: source/models.py:545
 msgid "Robots.txt active"
 msgstr "Robots.txt active"
 
-#: source/models.py:537
+#: source/models.py:562
 msgid "Seed"
 msgstr "Seed"
 

--- a/Seeder/settings/base.py
+++ b/Seeder/settings/base.py
@@ -287,6 +287,7 @@ WAYBACK_URL = "http://wayback.webarchiv.cz/wayback/query?type=urlquery&url={url}
 
 
 SEEDS_EXPORT_DIR = 'seeds'
+SEEDS_BACKUP_DIR = os.path.join(SEEDS_EXPORT_DIR, 'backup')
 MANET_URL = '127.0.0.1:8891'
 
 

--- a/Seeder/settings/env.py
+++ b/Seeder/settings/env.py
@@ -34,6 +34,9 @@ ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '127.0.0.1').split(' ')
 
 INTERNAL_IPS = os.environ.get('INTERNAL_IPS', '127.0.0.1').split(' ')
 
+FILE_UPLOAD_MAX_MEMORY_SIZE = int(os.environ.get(
+    'FILE_UPLOAD_MAX_MEMORY_SIZE', 52428800))  # 50*1024*1024 = 50 MiB
+
 # Database
 # https://docs.djangoproject.com/en/1.7/ref/settings/#databases
 # since we use special PostgresSQL fields we cannot simply use any db.

--- a/Seeder/source/urls.py
+++ b/Seeder/source/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     path('seed/<int:pk>', SeedEdit.as_view(), name='seed_edit'),
     path('history/<int:pk>', History.as_view(), name='history'),
     path('list', SourceList.as_view(), name='list'),
-    path('export', download_source_xlsx, name='export'),
+    path('export', SourceExportAll.as_view(), name='export'),
     path('category_autocomplete', CategoryAutocomplete.as_view(),
          name='category_autocomplete'),
     path('subcategory_autocomplete', SubcategoryAutocomplete.as_view(),

--- a/Seeder/source/views.py
+++ b/Seeder/source/views.py
@@ -243,19 +243,20 @@ class SourceList(SourceView, generic_views.FilteredListView):
     full_export_url = 'source:export'
 
 
-def download_source_xlsx(request):
-    """ Download all sources in an XLSX file """
-    from .models import Source
-    from django.http import HttpResponse
-    df = Source.export_all_sources()
-    # Export the DF straight into a downloading response
-    filename = f"sources_{datetime.now():%Y-%m-%d}.xlsx"
-    response = HttpResponse(
-        content_type=("application/vnd.openxmlformats-officedocument."
-                      "spreadsheetml.sheet"))
-    response["Content-Disposition"] = f"attachment; filename={filename}"
-    df.to_excel(response, index=False, engine="openpyxl")
-    return response
+class SourceExportAll(SourceView, View):
+    def get(self, request):
+        """ Download all sources in an XLSX file """
+        from .models import Source
+        from django.http import HttpResponse
+        df = Source.export_all_sources()
+        # Export the DF straight into a downloading response
+        filename = f"sources_{datetime.now():%Y-%m-%d}.xlsx"
+        response = HttpResponse(
+            content_type=("application/vnd.openxmlformats-officedocument."
+                          "spreadsheetml.sheet"))
+        response["Content-Disposition"] = f"attachment; filename={filename}"
+        df.to_excel(response, index=False, engine="openpyxl")
+        return response
 
 
 class CategoryAutocomplete(autocomplete.Select2QuerySetView):

--- a/Seeder/static/seeder-assets/site.webmanifest
+++ b/Seeder/static/seeder-assets/site.webmanifest
@@ -1,1 +1,19 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "",
+  "short_name": "",
+  "icons": [
+    {
+      "src": "/static/seeder-assets/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/static/seeder-assets/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/ci/nginx.conf
+++ b/ci/nginx.conf
@@ -5,5 +5,9 @@ server {
     location /media/ {
         root /seeder;
     }
-  listen 0.0.0.0:80;
+
+    # Increase max upload size to ~50MB
+    client_max_body_size 53M;
+
+    listen 0.0.0.0:80;
 }


### PR DESCRIPTION
- site.webmanifest static URL fix
- new utility command `generate_unique_seeds --base-url --num --output` to generate unique seeds for testing large custom seeds upload
- add Topic Collection custom_seeds backup functionality into media/seeds/backup
- source XLSX export is now login-protected
- #636  enable upload of very large custom_seeds through a TXT file
    - TC edit form doesn't allow manual edit of custom seeds when there's more than 1MB of them, only overwriting
    - seeds only get paired when there's a small number of seeds (<1MB)
    - TC saves are optimized to not save custom_seeds if not necessary (becomes a big problem when size is in 10s of MB)