### PR TITLE
EW: fix divide by zero error, use default django-tables2 template, add # of records for tables

### DIFF
--- a/Seeder/www/tables.py
+++ b/Seeder/www/tables.py
@@ -47,4 +47,4 @@ class ExtinctWebsitesTable(tables.Table):
             'class': 'table table-sm table-striped table-hover'
         }
         order_by = ("id",)
-        template_name = "django_tables2/bootstrap-responsive.html"
+        # template_name = "django_tables2/bootstrap-responsive.html"

--- a/Seeder/www/templates/extinct_websites/summary.html
+++ b/Seeder/www/templates/extinct_websites/summary.html
@@ -26,10 +26,10 @@
             }
         </style>
 
-        <h2>{% trans "Všechny aktuálně mrtvé weby" %}</h2>
+        <h2>{% trans "Všechny aktuálně mrtvé weby" %} ({{ tables.0.data|length }})</h2>
         {% render_table tables.0 %}
 
-        <h2>{% trans "Všechny aktuálně trackované weby" %}</h2>
+        <h2>{% trans "Všechny aktuálně trackované weby" %} ({{ tables.1.data|length }})</h2>
         {% render_table tables.1 %}
     </section>
 </div>


### PR DESCRIPTION
It's bizarre... the data has loaded correctly but the tables are empty without raising any errors. So, troubleshooting django-tables2 now.