### PR TITLE
ArchiveIt "frozen_only" & other bugfixes

### DIFF
--- a/Seeder/harvests/models.py
+++ b/Seeder/harvests/models.py
@@ -323,7 +323,7 @@ class Harvest(HarvestAbstractModel):
 
     def get_serials_frequency_json(self, frequency):
         # Disregard OneShot seeds, should be dealt with separately
-        if frequency == 0:
+        if str(frequency) == "0":
             return None
         seeds = set(Seed.objects.archiving().filter(
             source__frequency=frequency).values_list('url', flat=True))
@@ -440,8 +440,10 @@ class Harvest(HarvestAbstractModel):
     def get_seeds_by_frequency(self):
         if not self.target_frequency:
             return set()
+        # Ignore "0" frequency, oneshot dealt with separately
         seeds = Seed.objects.archiving().filter(
-            source__frequency__in=self.target_frequency)
+            source__frequency__in=self.target_frequency
+        ).exclude(source__frequency=0)
         blacklisted = self.get_blacklisted()
         return set(seeds.values_list('url', flat=True)) - blacklisted
 

--- a/Seeder/harvests/templates/harvest_autoselect.html
+++ b/Seeder/harvests/templates/harvest_autoselect.html
@@ -1,4 +1,6 @@
 <script>
+    // Are we in an edit/add form?
+    const editing = `{{ editing }}`.toLowerCase() === "true";
     // Assign all relevant fields to constant variables
     {% if harvest_form %}
     // Harvest type
@@ -47,7 +49,10 @@
             combined.prop("checked", false);
         }
     }
-    function harvestTypeSelected(harvestType) {
+    /**
+    updateValues: if true, update values such as archive_it. Used for edit form.
+    */
+    function harvestTypeSelected(harvestType, updateValues) {
         // Reset things back to the default state – everything enabled, all sections shown
         function defaults() {
             $(".harvest_properties").prop("disabled", false);
@@ -59,7 +64,9 @@
         // Serials = check Archive-it, disable Test, hide sections 'topic_collections', 'topic_collection_frequency'
         if (harvestType == "serials") {
             defaults();
-            archive_it.prop("checked", true);
+            if (updateValues) {
+                archive_it.prop("checked", true);
+            }
             tests.prop("checked", false);
             tests.prop("disabled", true);
             autoSelectCombined()
@@ -94,9 +101,9 @@
             autoSelectCombined()
         } else console.warn("Unknown harvest type", harvestType)
     }
-    harvestTypeSelected(harvest_type.val()); // Set initially
+    harvestTypeSelected(harvest_type.val(), !editing); // Set initially, don't update values when editing
     harvest_type.on("change", (e) => {
-        harvestTypeSelected(e.currentTarget.value);
+        harvestTypeSelected(e.currentTarget.value, true);
     })
 
     // When Harvest Properties are un/checked, do stuff

--- a/Seeder/harvests/templates/harvest_edit_form.html
+++ b/Seeder/harvests/templates/harvest_edit_form.html
@@ -2,7 +2,7 @@
 
 {% block extrajs %}
 {{ block.super }}
-{% include "harvest_autoselect.html" %}
+{% include "harvest_autoselect.html" with editing=True %}
 {% include "harvest_config_ajax.html" %}
 {% include "harvest_clear_tcs.html" %}
 {% endblock %}


### PR DESCRIPTION
RE #534 
- `get_seeds` now accepts an argument `frozen_only`, which preemptively returns an empty set if True and seeds haven't been frozen yet. This is so that old not frozen Harvests don't recursively slow down `get_previously_harvested`
- Fixed bug in "get seeds by frequency" where "0-frequency" seeds were being included – these are now only included in `get_oneshot_seeds` under oneshot conditions (not previously harvested, ...)
- When editing a Harvest, don't auto-select "ArchiveIt" when it wasn't selected previously. When changing harvest type or creating a new Harvest, the behaviour is unchanged – ArchiveIt is checked by default.