### PR TITLE
#713: filtr smluv dle roku

### DIFF
--- a/Seeder/contracts/field_filters.py
+++ b/Seeder/contracts/field_filters.py
@@ -6,12 +6,8 @@ from core.custom_filters import BaseFilterSet, DateRangeFilter
 
 
 def filter_contract_number(queryset, name, value):
-    # value in format e.g. '64 / 2017'
-    try:
-        contract_number, year = [int(s.strip()) for s in value.split('/')]
-        return queryset.filter(contract_number=contract_number, year=year)
-    except Exception:
-        return queryset.none()
+    # Use the ContractQuerySet method for consistent filtering logic
+    return queryset.filter_by_contract_number(value)
 
 
 def filter_creative_commons(queryset, name, value):

--- a/Seeder/source/models.py
+++ b/Seeder/source/models.py
@@ -187,12 +187,9 @@ class SourceQuerySet(models.QuerySet):
 
     def contains_contract_number(self, value):
         from contracts.models import Contract
-        try:
-            contract_number, year = [int(s.strip()) for s in value.split('/')]
-            return self.filter(contract__in=Contract.objects.valid().filter(
-                contract_number=contract_number, year=year))
-        except Exception:
-            return self.none()
+        # Use the ContractQuerySet method for consistent filtering logic
+        contracts = Contract.objects.filter_by_contract_number(value)
+        return self.filter(contract__in=contracts)
 
 
 class SourceManager(models.Manager.from_queryset(SourceQuerySet)):


### PR DESCRIPTION
Upravil jsem contract_number filter, aby fungoval jak s plným číslem smlouvy (např. "10/2022") tak se samotným rokem (např. "2022"). Toto se aplikuje jak při filtrování smluv, tak při filtrování zdrojů podle čísla smlouvy.