### PR TITLE
Feat/#636 chunked upload

### DIFF
--- a/Seeder/harvests/cron.py
+++ b/Seeder/harvests/cron.py
@@ -1,0 +1,28 @@
+from django.utils import timezone
+
+from chunked_upload.models import ChunkedUpload
+from chunked_upload.settings import EXPIRATION_DELTA
+
+
+def cleanup_expired_chunked_uploads():
+    """
+    Delete expired chunked uploads (DB rows + temp files on disk).
+
+    This is intended to run from daily cron and prevents abandoned partial
+    uploads from consuming storage indefinitely.
+    """
+    expire_before = timezone.now() - EXPIRATION_DELTA
+    stale_uploads = ChunkedUpload.objects.filter(
+        created_on__lte=expire_before).order_by("created_on")
+
+    removed = 0
+    reclaimed_bytes = 0
+    for upload in stale_uploads.iterator():
+        reclaimed_bytes += upload.offset or 0
+        upload.delete()
+        removed += 1
+
+    print(
+        "Removed {} expired chunk uploads, reclaimed ~{} bytes".format(
+            removed, reclaimed_bytes)
+    )

--- a/Seeder/harvests/forms.py
+++ b/Seeder/harvests/forms.py
@@ -203,10 +203,16 @@ class InternalTopicCollectionForm(forms.ModelForm):
 
 class InternalTopicCollectionEditForm(InternalTopicCollectionForm):
     files_to_delete = forms.MultipleChoiceField(required=False)
-    custom_seeds_file = forms.FileField(required=False, help_text=_L(
-        "Provide a text file with one seed per line which will overwrite "
-        "all custom_seeds. The original custom_seeds will be backed up to "
-        "the media/seeds/backup folder."))
+    custom_seeds_upload_id = forms.CharField(
+        required=False,
+        widget=forms.HiddenInput(),
+        help_text=_L(
+            "Upload a .txt file (chunked upload, up to 500MB) with one seed "
+            "per line. After upload completes and this form is submitted, it "
+            "will overwrite all custom_seeds. The original custom_seeds will "
+            "be backed up to the media/seeds/backup folder."
+        ),
+    )
     ''' Maximum length of custom seeds (chars) to be displayed & editable '''
     CUSTOM_SEEDS_MAXLEN = 1 * 1000 * 1000  # 1MB
 
@@ -224,13 +230,16 @@ class InternalTopicCollectionEditForm(InternalTopicCollectionForm):
             # Remove initial value so it doesn't get "re-saved"
             if "custom_seeds" in self.initial:
                 del self.initial["custom_seeds"]
-            self.fields["custom_seeds_file"].help_text += "<br /><b>" + _(
-                "Custom seeds field is disabled because there are too many "
-                "seeds to be displayed in an HTML text field.") + "</b>"
+            self.fields["custom_seeds_upload_id"].help_text += (
+                "<br /><b>" + _(
+                    "Custom seeds field is disabled because there are too many "
+                    "seeds to be displayed in an HTML text field."
+                ) + "</b>"
+            )
 
     class Meta(InternalTopicCollectionForm.Meta):
         fields = InternalTopicCollectionForm.Meta.fields + \
-            ('files_to_delete', 'custom_seeds_file')
+            ('files_to_delete', 'custom_seeds_upload_id')
 
 
 class ExternalTopicCollectionForm(forms.ModelForm):

--- a/Seeder/harvests/templates/internal_tc_edit_form.html
+++ b/Seeder/harvests/templates/internal_tc_edit_form.html
@@ -1,0 +1,77 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load bootstrap3 static %}
+
+{% block title %}
+    {% trans 'Edit' %} {{ object }}
+{% endblock %}
+
+{% block page_header %}
+    {% trans 'Edit' %} {{ object }}
+{% endblock %}
+
+{% block extrahead %}
+{{ form.media }}
+{% endblock %}
+
+{% block content %}
+    <form
+        id="internal-tc-edit-form"
+        method="post"
+        enctype="multipart/form-data"
+        data-chunk-upload-url="{% url 'harvests:internal_collection_custom_seeds_chunk_upload' pk=object.pk %}"
+        data-chunk-complete-url="{% url 'harvests:internal_collection_custom_seeds_chunk_complete' pk=object.pk %}"
+        data-chunk-size="4194304"
+    >
+        {% csrf_token %}
+        {% bootstrap_form form exclude='custom_seeds_upload_id' %}
+        {{ form.custom_seeds_upload_id }}
+
+        <div class="form-group" id="custom-seeds-chunk-upload">
+            <label for="id_custom_seeds_chunk_file">
+                {% trans "Custom seeds upload (.txt)" %}
+            </label>
+            <input
+                id="id_custom_seeds_chunk_file"
+                type="file"
+                class="form-control"
+                accept=".txt,text/plain,application/octet-stream"
+            />
+            <p class="help-block">{{ form.custom_seeds_upload_id.help_text|safe }}</p>
+            <div class="progress">
+                <div
+                    id="custom-seeds-upload-progress"
+                    class="progress-bar"
+                    role="progressbar"
+                    aria-valuemin="0"
+                    aria-valuemax="100"
+                    aria-valuenow="0"
+                    style="width: 0%;"
+                >
+                    0%
+                </div>
+            </div>
+            <p
+                id="custom-seeds-upload-status"
+                class="help-block"
+                data-default-text="{% trans 'No upload in progress.' %}"
+            >
+                {% trans 'No upload in progress.' %}
+            </p>
+        </div>
+
+        <input
+            id="internal-tc-edit-submit"
+            type="submit"
+            class="btn btn-primary btn-block"
+            value="{% trans 'Send' %}"
+        />
+    </form>
+{% endblock %}
+
+{% block extrajs %}
+{{ block.super }}
+<script src="{% static 'harvests/vendor/spark-md5.min.js' %}"></script>
+<script src="{% static 'harvests/internal_tc_chunked_upload.js' %}"></script>
+{% include "internal_tc_title_autofill.html" %}
+{% endblock %}

--- a/Seeder/harvests/tests.py
+++ b/Seeder/harvests/tests.py
@@ -1,12 +1,24 @@
+import json
+import os
+import shutil
+import tempfile
+from hashlib import md5
 from datetime import datetime, timedelta
 
 from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, Client
+from django.test.utils import override_settings
 from django.urls import reverse
+from django.utils import timezone
 
 from source.constants import SOURCE_FREQUENCY_PER_YEAR
+from harvests.cron import cleanup_expired_chunked_uploads
 from harvests.scheduler import get_dates_for_timedelta
-from harvests.models import Harvest, TopicCollection
+from harvests.models import Attachment, Harvest, TopicCollection
+from harvests.views import INTERNAL_TC_CUSTOM_SEEDS_UPLOADS_SESSION_KEY
+from chunked_upload.constants import COMPLETE
+from chunked_upload.models import ChunkedUpload
 
 TODAY = datetime.today()
 
@@ -265,6 +277,391 @@ class HarvestUrlTest(TestCase):
         for h in harvests:
             self.assertEqual(self.DATE, h.scheduled_on)
             self.assertTrue('0' in h.target_frequency)
+
+
+@override_settings(CHUNKED_UPLOAD_MAX_BYTES=524288000)
+class InternalTopicCollectionChunkedUploadTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser('pedro', '', 'password')
+        self.c = Client()
+        self.c.login(username='pedro', password='password')
+        self.topic = TopicCollection.objects.order_by("pk").first()
+        if not self.topic:
+            self.topic = TopicCollection(owner=self.user)
+        self.topic.owner = self.user
+        self.topic.title_cs = "Chunk upload topic cs"
+        self.topic.title_en = "Chunk upload topic en"
+        self.topic.annotation_cs = "annotation cs"
+        self.topic.annotation_en = "annotation en"
+        self.topic.custom_seeds = "https://old.example.com\n"
+        self.topic.all_open = True
+        self.topic.save()
+
+        self.media_root = tempfile.mkdtemp(prefix="seeder-test-media-")
+        self.override_media = override_settings(MEDIA_ROOT=self.media_root)
+        self.override_media.enable()
+        self.addCleanup(self.override_media.disable)
+        self.addCleanup(shutil.rmtree, self.media_root, True)
+
+    def _chunk_upload_url(self):
+        return reverse(
+            "harvests:internal_collection_custom_seeds_chunk_upload",
+            kwargs={"pk": self.topic.pk},
+        )
+
+    def _chunk_complete_url(self):
+        return reverse(
+            "harvests:internal_collection_custom_seeds_chunk_complete",
+            kwargs={"pk": self.topic.pk},
+        )
+
+    def _edit_url(self):
+        return reverse(
+            "harvests:internal_collection_edit",
+            kwargs={"pk": self.topic.pk},
+        )
+
+    def _post_chunk(
+            self, content, filename="custom-seeds.txt", content_type="text/plain",
+            total=None, upload_id=None):
+        total_bytes = total if total is not None else len(content)
+        data = {
+            "file": SimpleUploadedFile(filename, content, content_type=content_type),
+            "filename": filename,
+            "offset": "0",
+        }
+        if upload_id:
+            data["upload_id"] = upload_id
+        return self.c.post(
+            self._chunk_upload_url(),
+            data,
+            HTTP_CONTENT_RANGE=f"bytes 0-{len(content) - 1}/{total_bytes}",
+        )
+
+    def _complete_upload(self, upload_id, md5_hex):
+        return self.c.post(
+            self._chunk_complete_url(),
+            data={"upload_id": upload_id, "md5": md5_hex},
+        )
+
+    def _edit_payload(self, **kwargs):
+        payload = {
+            "owner": str(self.user.pk),
+            "collection_alias": self.topic.collection_alias or "",
+            "title_cs": self.topic.title_cs,
+            "title_en": self.topic.title_en,
+            "annotation_cs": self.topic.annotation_cs,
+            "annotation_en": self.topic.annotation_en,
+            "date_from": self.topic.date_from.strftime("%Y-%m-%d"),
+            "date_to": "",
+            "aggregation_with_same_type": "on",
+            "all_open": "on",
+            "target_frequency": [],
+            "custom_seeds": self.topic.custom_seeds or "",
+            "custom_sources": [],
+            "files_to_delete": [],
+            "custom_seeds_upload_id": "",
+        }
+        payload.update(kwargs)
+        return payload
+
+    def test_chunk_upload_happy_path(self):
+        content = b"https://example.com\nhttps://example.org\n"
+        response = self._post_chunk(content)
+        self.assertEqual(200, response.status_code)
+        payload = json.loads(response.content.decode("utf-8"))
+        upload_id = payload["upload_id"]
+        self.assertTrue(upload_id)
+        self.assertEqual(len(content), payload["offset"])
+
+        complete = self._complete_upload(upload_id, md5(content).hexdigest())
+        self.assertEqual(200, complete.status_code)
+        chunked_upload = ChunkedUpload.objects.get(upload_id=upload_id)
+        self.assertEqual(COMPLETE, chunked_upload.status)
+
+    def test_unauthenticated_upload_is_denied(self):
+        anon = Client()
+        response = anon.post(
+            self._chunk_upload_url(),
+            data={
+                "file": SimpleUploadedFile(
+                    "custom-seeds.txt", b"https://example.com\n",
+                    content_type="text/plain"),
+                "filename": "custom-seeds.txt",
+                "offset": "0",
+            },
+            HTTP_CONTENT_RANGE="bytes 0-19/20",
+        )
+        self.assertEqual(302, response.status_code)
+        self.assertIn("/seeder/auth/login/", response.url)
+
+    def test_invalid_extension_is_rejected(self):
+        response = self._post_chunk(
+            b"https://example.com\n",
+            filename="custom-seeds.csv",
+            content_type="text/plain",
+        )
+        self.assertEqual(400, response.status_code)
+        payload = json.loads(response.content.decode("utf-8"))
+        self.assertIn("Only .txt files are allowed", payload["detail"])
+
+    def test_too_large_upload_is_rejected(self):
+        response = self._post_chunk(
+            b"https://example.com\n",
+            total=524288001,
+        )
+        self.assertEqual(400, response.status_code)
+        payload = json.loads(response.content.decode("utf-8"))
+        self.assertIn("Size of file exceeds the limit", payload["detail"])
+
+    def test_checksum_mismatch_is_rejected(self):
+        content = b"https://example.com\n"
+        response = self._post_chunk(content)
+        self.assertEqual(200, response.status_code)
+        upload_id = json.loads(response.content.decode("utf-8"))["upload_id"]
+
+        complete = self._complete_upload(upload_id, "wrong-md5")
+        self.assertEqual(400, complete.status_code)
+        payload = json.loads(complete.content.decode("utf-8"))
+        self.assertIn("md5 checksum does not match", payload["detail"])
+
+    def test_form_submit_with_valid_upload_replaces_custom_seeds(self):
+        new_seeds = b"https://new.example.com\nhttps://newer.example.com\n"
+        upload = self._post_chunk(new_seeds)
+        upload_id = json.loads(upload.content.decode("utf-8"))["upload_id"]
+        self._complete_upload(upload_id, md5(new_seeds).hexdigest())
+
+        response = self.c.post(
+            self._edit_url(),
+            data=self._edit_payload(custom_seeds_upload_id=upload_id),
+        )
+        self.assertEqual(302, response.status_code)
+
+        self.topic.refresh_from_db()
+        self.assertEqual(new_seeds.decode("utf-8"), self.topic.custom_seeds)
+        self.assertFalse(ChunkedUpload.objects.filter(upload_id=upload_id).exists())
+
+        backup_dir = os.path.join(self.media_root, "seeds", "backup")
+        self.assertTrue(os.path.isdir(backup_dir))
+        self.assertTrue(os.listdir(backup_dir))
+
+    def test_upload_submit_invalidates_stale_frozen_cache(self):
+        self.topic.seeds_frozen = "https://old.example.com"
+        self.topic.save(update_fields=["seeds_frozen"])
+
+        new_seeds = b"https://new1.example.com\nhttps://new2.example.com\n"
+        upload = self._post_chunk(new_seeds)
+        upload_id = json.loads(upload.content.decode("utf-8"))["upload_id"]
+        self._complete_upload(upload_id, md5(new_seeds).hexdigest())
+
+        response = self.c.post(
+            self._edit_url(),
+            data=self._edit_payload(custom_seeds_upload_id=upload_id),
+        )
+        self.assertEqual(302, response.status_code)
+
+        self.topic.refresh_from_db()
+        self.assertEqual("", self.topic.seeds_frozen)
+        self.assertSetEqual(
+            {"https://new1.example.com", "https://new2.example.com"},
+            self.topic.get_seeds(),
+        )
+
+    def test_invalid_upload_id_does_not_apply_other_changes(self):
+        attachment = Attachment.objects.create(
+            topic_collection=self.topic,
+            file=SimpleUploadedFile(
+                "keep.txt", b"keep me", content_type="text/plain"),
+        )
+
+        old_title = self.topic.title_cs
+        response = self.c.post(
+            self._edit_url(),
+            data=self._edit_payload(
+                title_cs="Should not persist",
+                files_to_delete=[str(attachment.pk)],
+                custom_seeds_upload_id="missing-upload",
+            ),
+        )
+        self.assertEqual(302, response.status_code)
+
+        self.topic.refresh_from_db()
+        self.assertEqual(old_title, self.topic.title_cs)
+        self.assertTrue(Attachment.objects.filter(pk=attachment.pk).exists())
+
+    def test_consumed_upload_cannot_be_reused(self):
+        new_seeds = b"https://new.example.com\n"
+        upload = self._post_chunk(new_seeds)
+        upload_id = json.loads(upload.content.decode("utf-8"))["upload_id"]
+        self._complete_upload(upload_id, md5(new_seeds).hexdigest())
+
+        first = self.c.post(
+            self._edit_url(),
+            data=self._edit_payload(custom_seeds_upload_id=upload_id),
+        )
+        self.assertEqual(302, first.status_code)
+
+        original_title = self.topic.title_cs
+        second = self.c.post(
+            self._edit_url(),
+            data=self._edit_payload(
+                title_cs="Should not save on reuse",
+                custom_seeds_upload_id=upload_id,
+            ),
+        )
+        self.assertEqual(302, second.status_code)
+
+        self.topic.refresh_from_db()
+        self.assertEqual(original_title, self.topic.title_cs)
+
+    def test_backup_filename_is_sanitized(self):
+        self.topic.title_cs = "../../unsafe title"
+        self.topic.title_en = "../../unsafe title"
+        self.topic.save(update_fields=["title_cs", "title_en"])
+
+        backup_url = self.topic.backup_custom_seeds()
+        self.assertNotIn("..", backup_url)
+
+        backup_dir = os.path.abspath(os.path.join(
+            self.media_root, "seeds", "backup"))
+        backup_files = os.listdir(backup_dir)
+        self.assertTrue(backup_files)
+
+        backup_path = os.path.abspath(os.path.join(backup_dir, backup_files[0]))
+        self.assertEqual(
+            backup_dir, os.path.commonpath([backup_dir, backup_path]))
+
+    def test_starting_new_upload_prunes_old_topic_uploads_in_session(self):
+        first_content = b"https://one.example.com\n"
+        first_upload = self._post_chunk(first_content)
+        first_upload_id = json.loads(first_upload.content.decode("utf-8"))[
+            "upload_id"]
+
+        second_content = b"https://two.example.com\n"
+        second_upload = self._post_chunk(second_content)
+        second_upload_id = json.loads(second_upload.content.decode("utf-8"))[
+            "upload_id"]
+
+        self.assertNotEqual(first_upload_id, second_upload_id)
+        self.assertFalse(
+            ChunkedUpload.objects.filter(upload_id=first_upload_id).exists()
+        )
+        self.assertTrue(
+            ChunkedUpload.objects.filter(upload_id=second_upload_id).exists()
+        )
+
+        bindings = self.c.session.get(
+            INTERNAL_TC_CUSTOM_SEEDS_UPLOADS_SESSION_KEY, {})
+        self.assertNotIn(first_upload_id, bindings)
+        self.assertIn(second_upload_id, bindings)
+
+    def test_cleanup_expired_chunked_uploads_removes_old_files(self):
+        old_content = b"https://old.example.com\n"
+        old_upload = ChunkedUpload.objects.create(
+            user=self.user,
+            filename="old.txt",
+            file=SimpleUploadedFile(
+                "old.txt", old_content, content_type="text/plain"),
+            offset=len(old_content),
+            status=COMPLETE,
+        )
+        old_upload_id = old_upload.upload_id
+        old_file_path = old_upload.file.path
+        old_created = timezone.now() - timedelta(days=2)
+        ChunkedUpload.objects.filter(pk=old_upload.pk).update(
+            created_on=old_created)
+
+        fresh_content = b"https://fresh.example.com\n"
+        fresh_upload = ChunkedUpload.objects.create(
+            user=self.user,
+            filename="fresh.txt",
+            file=SimpleUploadedFile(
+                "fresh.txt", fresh_content, content_type="text/plain"),
+            offset=len(fresh_content),
+            status=COMPLETE,
+        )
+        fresh_upload_id = fresh_upload.upload_id
+
+        self.assertTrue(os.path.exists(old_file_path))
+        cleanup_expired_chunked_uploads()
+
+        self.assertFalse(
+            ChunkedUpload.objects.filter(upload_id=old_upload_id).exists()
+        )
+        self.assertFalse(os.path.exists(old_file_path))
+        self.assertTrue(
+            ChunkedUpload.objects.filter(upload_id=fresh_upload_id).exists()
+        )
+        self.assertTrue(os.path.exists(fresh_upload.file.path))
+
+    def test_form_submit_with_upload_also_saves_other_changes(self):
+        new_seeds = b"https://new.example.com\n"
+        upload = self._post_chunk(new_seeds)
+        upload_id = json.loads(upload.content.decode("utf-8"))["upload_id"]
+        self._complete_upload(upload_id, md5(new_seeds).hexdigest())
+
+        response = self.c.post(
+            self._edit_url(),
+            data=self._edit_payload(
+                custom_seeds_upload_id=upload_id,
+                title_cs="Changed title while importing",
+            ),
+        )
+        self.assertEqual(302, response.status_code)
+
+        self.topic.refresh_from_db()
+        self.assertEqual("Changed title while importing", self.topic.title_cs)
+        self.assertEqual(new_seeds.decode("utf-8"), self.topic.custom_seeds)
+
+    def test_decode_error_preserves_custom_seeds(self):
+        old_custom_seeds = self.topic.custom_seeds
+        binary_data = b"\xff\xfe\xfd\xfc"
+        upload = self._post_chunk(binary_data)
+        upload_id = json.loads(upload.content.decode("utf-8"))["upload_id"]
+        self._complete_upload(upload_id, md5(binary_data).hexdigest())
+
+        response = self.c.post(
+            self._edit_url(),
+            data=self._edit_payload(custom_seeds_upload_id=upload_id),
+        )
+        self.assertEqual(302, response.status_code)
+
+        self.topic.refresh_from_db()
+        self.assertEqual(old_custom_seeds, self.topic.custom_seeds)
+        self.assertTrue(ChunkedUpload.objects.filter(upload_id=upload_id).exists())
+
+    def test_edit_without_upload_keeps_existing_behavior(self):
+        self.topic.custom_seeds = "x" * (1000 * 1000 + 10)
+        self.topic.save(update_fields=["custom_seeds"])
+
+        response = self.c.post(
+            self._edit_url(),
+            data=self._edit_payload(
+                title_cs="Chunk upload topic cs edited",
+                custom_seeds_upload_id="",
+            ),
+        )
+        self.assertEqual(302, response.status_code)
+        self.topic.refresh_from_db()
+        self.assertEqual("Chunk upload topic cs edited", self.topic.title_cs)
+
+    def test_edit_without_changes_skips_save_for_large_custom_seeds(self):
+        self.topic.custom_seeds = "x" * (1000 * 1000 + 10)
+        self.topic.seeds_frozen = "https://frozen.example.com"
+        self.topic.save(update_fields=["custom_seeds", "seeds_frozen"])
+        self.topic.refresh_from_db()
+        old_last_changed = self.topic.last_changed
+        old_seeds_frozen = self.topic.seeds_frozen
+
+        response = self.c.post(
+            self._edit_url(),
+            data=self._edit_payload(custom_seeds_upload_id=""),
+        )
+        self.assertEqual(302, response.status_code)
+
+        self.topic.refresh_from_db()
+        self.assertEqual(old_last_changed, self.topic.last_changed)
+        self.assertEqual(old_seeds_frozen, self.topic.seeds_frozen)
 
 
 class ScheduleTest(TestCase):

--- a/Seeder/harvests/urls.py
+++ b/Seeder/harvests/urls.py
@@ -29,6 +29,16 @@ internal_collections_urlpatterns = [
          name='internal_collection_add'),
     path('<int:pk>/edit', InternalCollectionEdit.as_view(),
          name='internal_collection_edit'),
+    path(
+        '<int:pk>/custom-seeds/chunk-upload',
+        InternalCollectionCustomSeedsChunkUploadView.as_view(),
+        name='internal_collection_custom_seeds_chunk_upload',
+    ),
+    path(
+        '<int:pk>/custom-seeds/chunk-upload/complete',
+        InternalCollectionCustomSeedsChunkCompleteView.as_view(),
+        name='internal_collection_custom_seeds_chunk_complete',
+    ),
     path('<int:pk>', InternalCollectionDetail.as_view(),
          name='internal_collection_detail'),
     path('<int:pk>/urls', InternalCollectionListUrls.as_view(),

--- a/Seeder/settings/base.py
+++ b/Seeder/settings/base.py
@@ -91,6 +91,7 @@ INSTALLED_APPS = (
     'captcha',
     'ordered_model',
     'solo',
+    'chunked_upload',
     # 'elasticstack',
     'core',
     'publishers',

--- a/Seeder/settings/base.py
+++ b/Seeder/settings/base.py
@@ -255,6 +255,7 @@ CRONTAB_COMMAND_PREFIX = "set -a; . /code/.cronenv; set +a;"
 CRONTAB_COMMAND_SUFFIX = ">> /var/log/cron.log 2>&1"
 CRONJOBS = [
     ('0 1 * * *', 'source.screenshots.take_screenshots'),
+    ('5 1 * * *', 'harvests.cron.cleanup_expired_chunked_uploads'),
     ('10 * * * *', 'voting.cron.revive_postponed_rounds'),
     ('20 * * * *', 'contracts.cron.expire_contracts'),
     ('30 * * * *', 'contracts.cron.send_emails'),

--- a/Seeder/settings/env.py
+++ b/Seeder/settings/env.py
@@ -1,5 +1,6 @@
 from .base import *
 import os
+from datetime import timedelta
 
 # Enviromental based configuration.
 
@@ -35,11 +36,17 @@ ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '127.0.0.1').split(' ')
 INTERNAL_IPS = os.environ.get('INTERNAL_IPS', '127.0.0.1').split(' ')
 
 FILE_UPLOAD_MAX_MEMORY_SIZE = int(os.environ.get(
-    'FILE_UPLOAD_MAX_MEMORY_SIZE', 524288000))  # 500*1024*1024 = 500 MiB
+    'FILE_UPLOAD_MAX_MEMORY_SIZE', 10485760))  # 10*1024*1024 = 10 MiB
+
+CHUNKED_UPLOAD_MAX_BYTES = int(os.environ.get(
+    'CHUNKED_UPLOAD_MAX_BYTES', 524288000))
+CHUNKED_UPLOAD_EXPIRATION_DELTA = timedelta(seconds=int(os.environ.get(
+    'CHUNKED_UPLOAD_EXPIRATION_DELTA', 21600)))
+CHUNKED_UPLOAD_PATH = os.environ.get('CHUNKED_UPLOAD_PATH', 'chunked_uploads')
 
 # POST data limits (for large custom seeds uploads)
 DATA_UPLOAD_MAX_MEMORY_SIZE = int(os.environ.get(
-    'DATA_UPLOAD_MAX_MEMORY_SIZE', 524288000))  # 500*1024*1024 = 500 MiB
+    'DATA_UPLOAD_MAX_MEMORY_SIZE', 10485760))  # 10*1024*1024 = 10 MiB
 DATA_UPLOAD_MAX_NUMBER_FIELDS = int(os.environ.get(
     'DATA_UPLOAD_MAX_NUMBER_FIELDS', 1000))  # Default Django limit
 DATA_UPLOAD_MAX_NUMBER_FILES = int(os.environ.get(

--- a/Seeder/static/harvests/internal_tc_chunked_upload.js
+++ b/Seeder/static/harvests/internal_tc_chunked_upload.js
@@ -1,0 +1,224 @@
+(function () {
+    "use strict";
+
+    var DEFAULT_CHUNK_SIZE = 4 * 1024 * 1024;
+
+    function parseJSONResponse(response) {
+        return response.text().then(function (text) {
+            if (!text) {
+                return {};
+            }
+            try {
+                return JSON.parse(text);
+            } catch (error) {
+                return {};
+            }
+        });
+    }
+
+    function getUploadErrorMessage(payload, fallback) {
+        if (payload && payload.detail) {
+            return payload.detail;
+        }
+        if (payload && payload.offset !== undefined) {
+            return fallback + " (offset " + payload.offset + ")";
+        }
+        return fallback;
+    }
+
+    function formatProgress(current, total) {
+        if (!total) {
+            return 0;
+        }
+        return Math.floor((current / total) * 100);
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        var form = document.getElementById("internal-tc-edit-form");
+        if (!form) {
+            return;
+        }
+
+        var uploadUrl = form.getAttribute("data-chunk-upload-url");
+        var completeUrl = form.getAttribute("data-chunk-complete-url");
+        var chunkSize = Number(form.getAttribute("data-chunk-size")) || DEFAULT_CHUNK_SIZE;
+
+        var fileInput = document.getElementById("id_custom_seeds_chunk_file");
+        var uploadIdInput = document.getElementById("id_custom_seeds_upload_id");
+        var submitButton = document.getElementById("internal-tc-edit-submit");
+        var progressBar = document.getElementById("custom-seeds-upload-progress");
+        var statusElement = document.getElementById("custom-seeds-upload-status");
+        var csrfInput = form.querySelector("input[name='csrfmiddlewaretoken']");
+
+        if (!uploadUrl || !completeUrl || !fileInput || !uploadIdInput ||
+                !submitButton || !progressBar || !statusElement || !csrfInput) {
+            return;
+        }
+
+        var defaultStatusText = statusElement.getAttribute("data-default-text") || "";
+        var csrfToken = csrfInput.value;
+        var state = {
+            hasSelectedFile: false,
+            uploading: false,
+            completed: false,
+            token: 0
+        };
+
+        function setStatus(text, isError) {
+            statusElement.textContent = text;
+            statusElement.classList.toggle("text-danger", Boolean(isError));
+            statusElement.classList.toggle("text-success", !isError && state.completed);
+        }
+
+        function setProgress(percent) {
+            var value = Math.max(0, Math.min(100, percent));
+            progressBar.style.width = value + "%";
+            progressBar.setAttribute("aria-valuenow", String(value));
+            progressBar.textContent = value + "%";
+        }
+
+        function syncSubmitLock() {
+            submitButton.disabled = state.uploading || (state.hasSelectedFile && !state.completed);
+        }
+
+        function resetUploadFields() {
+            uploadIdInput.value = "";
+            state.completed = false;
+            setProgress(0);
+        }
+
+        async function uploadFileInChunks(file, token) {
+            var uploadId = "";
+            var offset = 0;
+            var spark = new SparkMD5.ArrayBuffer();
+
+            state.uploading = true;
+            state.completed = false;
+            syncSubmitLock();
+            setStatus("Uploading custom seeds...", false);
+            setProgress(0);
+
+            try {
+                while (offset < file.size) {
+                    if (token !== state.token) {
+                        return;
+                    }
+
+                    var end = Math.min(offset + chunkSize, file.size);
+                    var chunk = file.slice(offset, end);
+                    var chunkBuffer = await chunk.arrayBuffer();
+                    spark.append(chunkBuffer);
+
+                    var chunkData = new FormData();
+                    chunkData.append("file", chunk, file.name);
+                    chunkData.append("filename", file.name);
+                    chunkData.append("offset", String(offset));
+                    if (uploadId) {
+                        chunkData.append("upload_id", uploadId);
+                    }
+
+                    var chunkResponse = await fetch(uploadUrl, {
+                        method: "POST",
+                        credentials: "same-origin",
+                        headers: {
+                            "X-CSRFToken": csrfToken,
+                            "Content-Range": "bytes " + offset + "-" + (end - 1) + "/" + file.size
+                        },
+                        body: chunkData
+                    });
+                    var chunkPayload = await parseJSONResponse(chunkResponse);
+
+                    if (!chunkResponse.ok) {
+                        throw new Error(getUploadErrorMessage(
+                            chunkPayload, "Chunk upload failed"));
+                    }
+
+                    uploadId = chunkPayload.upload_id;
+                    offset = chunkPayload.offset;
+                    setProgress(formatProgress(offset, file.size));
+                }
+
+                if (!uploadId) {
+                    throw new Error("Upload did not return upload id");
+                }
+
+                setStatus("Finalizing upload checksum...", false);
+                var completeData = new URLSearchParams();
+                completeData.append("upload_id", uploadId);
+                completeData.append("md5", spark.end());
+
+                var completeResponse = await fetch(completeUrl, {
+                    method: "POST",
+                    credentials: "same-origin",
+                    headers: {
+                        "X-CSRFToken": csrfToken,
+                        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
+                    },
+                    body: completeData.toString()
+                });
+                var completePayload = await parseJSONResponse(completeResponse);
+                if (!completeResponse.ok) {
+                    throw new Error(getUploadErrorMessage(
+                        completePayload, "Upload completion failed"));
+                }
+
+                if (token !== state.token) {
+                    return;
+                }
+
+                uploadIdInput.value = uploadId;
+                state.completed = true;
+                setProgress(100);
+                setStatus("Upload completed. You can submit the form.", false);
+            } catch (error) {
+                if (token !== state.token) {
+                    return;
+                }
+                resetUploadFields();
+                setStatus(error.message || "Upload failed", true);
+            } finally {
+                if (token === state.token) {
+                    state.uploading = false;
+                    syncSubmitLock();
+                }
+            }
+        }
+
+        fileInput.addEventListener("change", function () {
+            state.token += 1;
+            resetUploadFields();
+
+            var file = fileInput.files[0];
+            if (!file) {
+                state.hasSelectedFile = false;
+                state.uploading = false;
+                setStatus(defaultStatusText, false);
+                syncSubmitLock();
+                return;
+            }
+
+            state.hasSelectedFile = true;
+            if (!file.name.toLowerCase().endsWith(".txt")) {
+                setStatus("Only .txt files are allowed.", true);
+                syncSubmitLock();
+                return;
+            }
+
+            uploadFileInChunks(file, state.token);
+        });
+
+        form.addEventListener("submit", function (event) {
+            if (state.uploading) {
+                event.preventDefault();
+                setStatus("Please wait for the upload to finish before submitting.", true);
+                return;
+            }
+            if (state.hasSelectedFile && !uploadIdInput.value) {
+                event.preventDefault();
+                setStatus("Please complete file upload before submitting.", true);
+            }
+        });
+
+        syncSubmitLock();
+    });
+})();

--- a/Seeder/static/harvests/vendor/spark-md5.min.js
+++ b/Seeder/static/harvests/vendor/spark-md5.min.js
@@ -1,0 +1,230 @@
+/* Minimal SparkMD5-compatible ArrayBuffer hasher for chunked uploads. */
+(function (global) {
+    "use strict";
+
+    var HEX_CHARS = "0123456789abcdef".split("");
+
+    function add32(a, b) {
+        return (a + b) | 0;
+    }
+
+    function cmn(q, a, b, x, s, t) {
+        a = add32(add32(a, q), add32(x, t));
+        return add32((a << s) | (a >>> (32 - s)), b);
+    }
+
+    function ff(a, b, c, d, x, s, t) {
+        return cmn((b & c) | ((~b) & d), a, b, x, s, t);
+    }
+
+    function gg(a, b, c, d, x, s, t) {
+        return cmn((b & d) | (c & (~d)), a, b, x, s, t);
+    }
+
+    function hh(a, b, c, d, x, s, t) {
+        return cmn(b ^ c ^ d, a, b, x, s, t);
+    }
+
+    function ii(a, b, c, d, x, s, t) {
+        return cmn(c ^ (b | (~d)), a, b, x, s, t);
+    }
+
+    function md5cycle(state, block) {
+        var a = state[0];
+        var b = state[1];
+        var c = state[2];
+        var d = state[3];
+
+        a = ff(a, b, c, d, block[0], 7, -680876936);
+        d = ff(d, a, b, c, block[1], 12, -389564586);
+        c = ff(c, d, a, b, block[2], 17, 606105819);
+        b = ff(b, c, d, a, block[3], 22, -1044525330);
+        a = ff(a, b, c, d, block[4], 7, -176418897);
+        d = ff(d, a, b, c, block[5], 12, 1200080426);
+        c = ff(c, d, a, b, block[6], 17, -1473231341);
+        b = ff(b, c, d, a, block[7], 22, -45705983);
+        a = ff(a, b, c, d, block[8], 7, 1770035416);
+        d = ff(d, a, b, c, block[9], 12, -1958414417);
+        c = ff(c, d, a, b, block[10], 17, -42063);
+        b = ff(b, c, d, a, block[11], 22, -1990404162);
+        a = ff(a, b, c, d, block[12], 7, 1804603682);
+        d = ff(d, a, b, c, block[13], 12, -40341101);
+        c = ff(c, d, a, b, block[14], 17, -1502002290);
+        b = ff(b, c, d, a, block[15], 22, 1236535329);
+
+        a = gg(a, b, c, d, block[1], 5, -165796510);
+        d = gg(d, a, b, c, block[6], 9, -1069501632);
+        c = gg(c, d, a, b, block[11], 14, 643717713);
+        b = gg(b, c, d, a, block[0], 20, -373897302);
+        a = gg(a, b, c, d, block[5], 5, -701558691);
+        d = gg(d, a, b, c, block[10], 9, 38016083);
+        c = gg(c, d, a, b, block[15], 14, -660478335);
+        b = gg(b, c, d, a, block[4], 20, -405537848);
+        a = gg(a, b, c, d, block[9], 5, 568446438);
+        d = gg(d, a, b, c, block[14], 9, -1019803690);
+        c = gg(c, d, a, b, block[3], 14, -187363961);
+        b = gg(b, c, d, a, block[8], 20, 1163531501);
+        a = gg(a, b, c, d, block[13], 5, -1444681467);
+        d = gg(d, a, b, c, block[2], 9, -51403784);
+        c = gg(c, d, a, b, block[7], 14, 1735328473);
+        b = gg(b, c, d, a, block[12], 20, -1926607734);
+
+        a = hh(a, b, c, d, block[5], 4, -378558);
+        d = hh(d, a, b, c, block[8], 11, -2022574463);
+        c = hh(c, d, a, b, block[11], 16, 1839030562);
+        b = hh(b, c, d, a, block[14], 23, -35309556);
+        a = hh(a, b, c, d, block[1], 4, -1530992060);
+        d = hh(d, a, b, c, block[4], 11, 1272893353);
+        c = hh(c, d, a, b, block[7], 16, -155497632);
+        b = hh(b, c, d, a, block[10], 23, -1094730640);
+        a = hh(a, b, c, d, block[13], 4, 681279174);
+        d = hh(d, a, b, c, block[0], 11, -358537222);
+        c = hh(c, d, a, b, block[3], 16, -722521979);
+        b = hh(b, c, d, a, block[6], 23, 76029189);
+        a = hh(a, b, c, d, block[9], 4, -640364487);
+        d = hh(d, a, b, c, block[12], 11, -421815835);
+        c = hh(c, d, a, b, block[15], 16, 530742520);
+        b = hh(b, c, d, a, block[2], 23, -995338651);
+
+        a = ii(a, b, c, d, block[0], 6, -198630844);
+        d = ii(d, a, b, c, block[7], 10, 1126891415);
+        c = ii(c, d, a, b, block[14], 15, -1416354905);
+        b = ii(b, c, d, a, block[5], 21, -57434055);
+        a = ii(a, b, c, d, block[12], 6, 1700485571);
+        d = ii(d, a, b, c, block[3], 10, -1894986606);
+        c = ii(c, d, a, b, block[10], 15, -1051523);
+        b = ii(b, c, d, a, block[1], 21, -2054922799);
+        a = ii(a, b, c, d, block[8], 6, 1873313359);
+        d = ii(d, a, b, c, block[15], 10, -30611744);
+        c = ii(c, d, a, b, block[6], 15, -1560198380);
+        b = ii(b, c, d, a, block[13], 21, 1309151649);
+        a = ii(a, b, c, d, block[4], 6, -145523070);
+        d = ii(d, a, b, c, block[11], 10, -1120210379);
+        c = ii(c, d, a, b, block[2], 15, 718787259);
+        b = ii(b, c, d, a, block[9], 21, -343485551);
+
+        state[0] = add32(state[0], a);
+        state[1] = add32(state[1], b);
+        state[2] = add32(state[2], c);
+        state[3] = add32(state[3], d);
+    }
+
+    function blockFromBytes(bytes, offset) {
+        var block = new Array(16);
+        var i = 0;
+        var j = 0;
+        for (i = 0; i < 16; i += 1) {
+            j = offset + (i * 4);
+            block[i] = (
+                bytes[j] |
+                (bytes[j + 1] << 8) |
+                (bytes[j + 2] << 16) |
+                (bytes[j + 3] << 24)
+            );
+        }
+        return block;
+    }
+
+    function finalizeState(state, tail, totalLength) {
+        var finalLength = ((tail.length + 9 + 63) >> 6) << 6;
+        var buffer = new Uint8Array(finalLength);
+        var bitLength = totalLength * 8;
+        var low = bitLength >>> 0;
+        var high = Math.floor(bitLength / 0x100000000);
+        var i = 0;
+        var lengthOffset = 0;
+
+        buffer.set(tail);
+        buffer[tail.length] = 0x80;
+
+        lengthOffset = finalLength - 8;
+        buffer[lengthOffset] = low & 0xFF;
+        buffer[lengthOffset + 1] = (low >>> 8) & 0xFF;
+        buffer[lengthOffset + 2] = (low >>> 16) & 0xFF;
+        buffer[lengthOffset + 3] = (low >>> 24) & 0xFF;
+        buffer[lengthOffset + 4] = high & 0xFF;
+        buffer[lengthOffset + 5] = (high >>> 8) & 0xFF;
+        buffer[lengthOffset + 6] = (high >>> 16) & 0xFF;
+        buffer[lengthOffset + 7] = (high >>> 24) & 0xFF;
+
+        for (i = 0; i < finalLength; i += 64) {
+            md5cycle(state, blockFromBytes(buffer, i));
+        }
+    }
+
+    function rhex(n) {
+        var str = "";
+        var j = 0;
+        for (j = 0; j < 4; j += 1) {
+            str += HEX_CHARS[(n >> (j * 8 + 4)) & 0x0F] + HEX_CHARS[(n >> (j * 8)) & 0x0F];
+        }
+        return str;
+    }
+
+    function hex(state) {
+        return rhex(state[0]) + rhex(state[1]) + rhex(state[2]) + rhex(state[3]);
+    }
+
+    function hexToBinaryString(hexValue) {
+        var bytes = "";
+        var i = 0;
+        for (i = 0; i < hexValue.length; i += 2) {
+            bytes += String.fromCharCode(parseInt(hexValue.substr(i, 2), 16));
+        }
+        return bytes;
+    }
+
+    function SparkMD5ArrayBuffer() {
+        this.reset();
+    }
+
+    SparkMD5ArrayBuffer.prototype.reset = function () {
+        this._state = [1732584193, -271733879, -1732584194, 271733878];
+        this._tail = new Uint8Array(0);
+        this._length = 0;
+        return this;
+    };
+
+    SparkMD5ArrayBuffer.prototype.append = function (arrayBuffer) {
+        var incoming = arrayBuffer instanceof Uint8Array ?
+            arrayBuffer :
+            new Uint8Array(arrayBuffer);
+        var buffer = new Uint8Array(this._tail.length + incoming.length);
+        var offset = 0;
+
+        if (incoming.length === 0) {
+            return this;
+        }
+
+        buffer.set(this._tail, 0);
+        buffer.set(incoming, this._tail.length);
+        this._length += incoming.length;
+
+        while (offset + 64 <= buffer.length) {
+            md5cycle(this._state, blockFromBytes(buffer, offset));
+            offset += 64;
+        }
+        this._tail = buffer.slice(offset);
+        return this;
+    };
+
+    SparkMD5ArrayBuffer.prototype.end = function (raw) {
+        var state = [
+            this._state[0],
+            this._state[1],
+            this._state[2],
+            this._state[3]
+        ];
+        var digest = "";
+
+        finalizeState(state, this._tail, this._length);
+        digest = hex(state);
+        this.reset();
+
+        return raw ? hexToBinaryString(digest) : digest;
+    };
+
+    var SparkMD5 = global.SparkMD5 || {};
+    SparkMD5.ArrayBuffer = SparkMD5ArrayBuffer;
+    global.SparkMD5 = SparkMD5;
+})(this);

--- a/ci/nginx-reverse-proxy.conf
+++ b/ci/nginx-reverse-proxy.conf
@@ -26,17 +26,19 @@ server {
         proxy_read_timeout 60s;
     }
 
-    # Override upload limit for seeder admin area (custom seeds upload)
+    # Seeder app area: keep body cap small (chunk uploads are split requests)
+    # while allowing longer-running app responses.
     location /seeder/ {
-        client_max_body_size 500M;
+        client_max_body_size 10M;
         # Keep original proxy settings which are not inherited
         proxy_pass http://traefik;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        # Extended timeouts for large file processing
-        proxy_connect_timeout 60s;
+        # Extended timeouts for slower authenticated app operations
+        client_body_timeout 300s;
+        proxy_connect_timeout 300s;
         proxy_send_timeout 300s;
         proxy_read_timeout 300s;
     }

--- a/docs/plans/internal-topic-collection-chunked-seed-upload-500mb.md
+++ b/docs/plans/internal-topic-collection-chunked-seed-upload-500mb.md
@@ -1,0 +1,172 @@
+# Internal Topic Collection Seed Upload Plan (Chunked, 500MB)
+
+## Summary
+Replace the current single-request `custom_seeds_file` upload in Internal Topic Collection edit with `django-chunked-upload`, so large `.txt` seed imports are reliable on slow networks and do not require broad site-wide large upload allowances.
+
+This plan keeps current import semantics:
+- backup old `custom_seeds`
+- replace with uploaded UTF-8 text
+- do not auto-pair after file import
+
+## Decisions Locked In
+- `chunked_upload` is already installed and importable in container runtime.
+- Maximum chunked upload size: **500MB** (`524288000` bytes), matching current nginx convention.
+- `DATA_UPLOAD_MAX_MEMORY_SIZE` should be reduced to **10MB** by default, because chunked file payload is sent in `request.FILES` and this setting protects large non-file POST bodies.
+- Checksum strategy is fixed to **MD5** (required by `django-chunked-upload` completion flow), computed client-side incrementally with **SparkMD5** and sent as `md5` in complete request payload.
+
+## Prerequisites (must be done before coding)
+- Verify chunked upload migrations are applied:
+  - `./drun showmigrations chunked_upload`
+  - `./drun migrate`
+- Confirm runtime model/table for chunk uploads exists before implementing endpoint logic.
+
+## Current Flow (to replace)
+- Form field is direct file upload: `Seeder/harvests/forms.py:206`
+- Edit handler reads full uploaded file in one request: `Seeder/harvests/views.py:516`
+- Replace logic is in:
+  - backup call: `Seeder/harvests/views.py:518`
+  - decode + replace: `Seeder/harvests/views.py:520`
+  - warning "not paired automatically": `Seeder/harvests/views.py:530`
+
+## Target Flow
+1. User opens Internal TC edit form.
+2. User selects a `.txt` file.
+3. Browser uploads chunks asynchronously to dedicated Django endpoints.
+4. Browser sends completion request (with checksum) and gets `upload_id`.
+5. Browser stores `upload_id` in hidden field.
+6. User submits the normal edit form.
+7. Server resolves `upload_id`, decodes uploaded file as UTF-8, performs backup+replace, and deletes temporary chunk upload data.
+
+## File-by-File Implementation
+
+### 1) `Seeder/harvests/views.py`
+Add dedicated chunked upload views and wire them to Internal TC context:
+- `InternalCollectionCustomSeedsChunkUploadView`
+- `InternalCollectionCustomSeedsChunkCompleteView`
+
+Requirements:
+- authenticated access only
+- only for valid Internal TC `pk`
+- endpoint-level validation: `.txt` file only, `text/plain` or `application/octet-stream`
+- max bytes enforced by chunked upload settings (500MB)
+
+Update `InternalCollectionEdit.form_valid`:
+- replace `custom_seeds_file` handling with hidden `custom_seeds_upload_id`
+- when upload id is present:
+  - validate upload exists and is complete
+  - decode UTF-8; on decode failure show existing error message and abort replacement
+  - call `backup_custom_seeds()`
+  - assign decoded text to `topic.custom_seeds` and save
+  - preserve current success/warning messages
+  - remove consumed temp upload artifact
+- keep existing non-upload edit branches unchanged (`custom_seeds_too_large`, pair behavior when no file import)
+- explicitly update `topic.save(update_fields=...)` exclusion set to also exclude `custom_seeds_upload_id` (non-model form field), otherwise Django will raise on save.
+
+### 2) `Seeder/harvests/forms.py`
+In `InternalTopicCollectionEditForm`:
+- remove direct `custom_seeds_file = forms.FileField(...)` from server-handled upload path
+- add `custom_seeds_upload_id = forms.CharField(required=False, widget=forms.HiddenInput())`
+- update help text to explain chunked upload behavior and overwrite semantics
+- keep `files_to_delete` and other existing fields unchanged
+- update `__init__` logic that currently references `self.fields["custom_seeds_file"]`; retarget it to the new upload UI/help field path (or guard the access) so form init does not break when `custom_seeds_file` is removed.
+
+### 3) `Seeder/harvests/urls.py`
+Add two URL patterns under internal collections:
+- `collections/internal/<int:pk>/custom-seeds/chunk-upload`
+- `collections/internal/<int:pk>/custom-seeds/chunk-upload/complete`
+
+Use explicit URL names for template JS wiring.
+
+Effective routed endpoints (including global prefixes) will be:
+- `/seeder/harvests/collections/internal/<int:pk>/custom-seeds/chunk-upload`
+- `/seeder/harvests/collections/internal/<int:pk>/custom-seeds/chunk-upload/complete`
+
+### 4) New template for Internal TC edit
+Create `Seeder/harvests/templates/internal_tc_edit_form.html` and set:
+- `InternalCollectionEdit.template_name = 'internal_tc_edit_form.html'`
+
+Template responsibilities:
+- render existing form fields
+- add file picker UI for chunk upload
+- add progress/status UI
+- include hidden `custom_seeds_upload_id`
+- disable submit while upload is active
+- block submit if file selected but upload not completed
+
+### 5) New JS file for chunk upload client
+Create `Seeder/static/harvests/internal_tc_chunked_upload.js`.
+
+Responsibilities:
+- split selected file into chunks (recommended 4MB each)
+- POST chunks sequentially with required fields (`file`, `filename`, `offset`, optional `upload_id`)
+- compute incremental MD5 with SparkMD5 during chunk iteration and send final `md5` on complete request
+- fill hidden `custom_seeds_upload_id` on success
+- update progress UI and lock/unlock submit button
+- report failures clearly and keep submit blocked until fixed/retried
+
+Concrete implementation decision:
+- add SparkMD5 as a static vendor asset (for deterministic behavior across browsers), include it only on `internal_tc_edit_form.html`, and keep upload logic in `Seeder/static/harvests/internal_tc_chunked_upload.js`.
+
+### 6) `Seeder/settings/env.py`
+Add/update env-driven settings:
+- `CHUNKED_UPLOAD_MAX_BYTES = int(os.environ.get('CHUNKED_UPLOAD_MAX_BYTES', 524288000))`
+- `CHUNKED_UPLOAD_EXPIRATION_DELTA = int(os.environ.get('CHUNKED_UPLOAD_EXPIRATION_DELTA', 86400))`
+- `CHUNKED_UPLOAD_PATH = os.environ.get('CHUNKED_UPLOAD_PATH', 'chunked_uploads')`
+
+Lower non-file POST memory ceiling:
+- `DATA_UPLOAD_MAX_MEMORY_SIZE` default from `524288000` to `10485760` (10MB)
+
+Note:
+- Keep env override support so deployment can raise if another legitimate large non-file POST endpoint exists.
+
+## Data and Security Constraints
+- Upload endpoints must require login.
+- Upload id must not be accepted blindly:
+  - verify completion state
+  - verify it belongs to current authenticated context (at least current session/user + TC binding)
+  - enforce one-time consumption (after successful import, upload record/file must be deleted and upload id cannot be reused)
+- Accept only `.txt` imports for this workflow.
+- Keep large upload capability scoped to dedicated upload endpoints.
+
+## Potential Issues and Mitigations
+- Interrupted uploads / slow network:
+  - chunk retries + resumable offset behavior; clear client status on mismatch.
+- Orphaned temporary chunk files:
+  - delete on successful consume; add cleanup for expired uploads.
+- UTF-8 decode failure:
+  - retain current behavior: show error, do not replace `custom_seeds`.
+- Large text replacement memory spikes:
+  - avoid duplicate full in-memory copies where possible; keep worker limits monitored.
+- Hidden upload id tampering:
+  - server-side ownership/context checks before consuming upload.
+- Lower `DATA_UPLOAD_MAX_MEMORY_SIZE` side effect:
+  - if any endpoint depends on huge non-file POST bodies, that endpoint must get explicit handling or higher env value.
+
+## Testing Plan
+
+### Automated tests (harvests tests module)
+- authenticated chunk upload happy path
+- unauthenticated upload denied
+- invalid extension rejected
+- >500MB rejected
+- completion checksum mismatch rejected
+- form submit with valid `custom_seeds_upload_id` performs backup+replace
+- upload decode error preserves old `custom_seeds`
+- existing edit behavior without file upload remains unchanged
+
+### Manual checks
+- upload 300MB+ txt over throttled link
+- verify progress + final save
+- confirm warning: uploaded seeds are not auto-paired
+- verify backup file exists in `media/seeds/backup`
+
+## Acceptance Criteria
+- Internal TC edit supports `.txt` seed uploads up to 500MB reliably.
+- Upload no longer depends on a single long multipart request.
+- Current backup/replace/not-auto-pair semantics are preserved.
+- Default `DATA_UPLOAD_MAX_MEMORY_SIZE` is 10MB unless overridden by env.
+- Change is isolated to Internal TC edit workflow and dedicated upload endpoints.
+
+## Rollout Notes
+- This plan is Django-centric and does not require global nginx/traefik changes.
+- If edge proxy adjustments are needed later, restrict them to the new upload endpoint paths only.

--- a/docs/plans/internal-topic-collection-chunked-seed-upload-500mb.md
+++ b/docs/plans/internal-topic-collection-chunked-seed-upload-500mb.md
@@ -10,9 +10,153 @@ This plan keeps current import semantics:
 
 ## Decisions Locked In
 - `chunked_upload` is already installed and importable in container runtime.
-- Maximum chunked upload size: **500MB** (`524288000` bytes), matching current nginx convention.
+- Maximum logical chunked upload size: **500MB** (`524288000` bytes).
+  - this is enforced by Django chunked-upload settings, not by raising nginx
+    request body limits globally.
+- `FILE_UPLOAD_MAX_MEMORY_SIZE` default should be **10MB** so regular file
+  uploads do not buffer excessively in process memory.
 - `DATA_UPLOAD_MAX_MEMORY_SIZE` should be reduced to **10MB** by default, because chunked file payload is sent in `request.FILES` and this setting protects large non-file POST bodies.
 - Checksum strategy is fixed to **MD5** (required by `django-chunked-upload` completion flow), computed client-side incrementally with **SparkMD5** and sent as `md5` in complete request payload.
+
+## Initial Code Review Stage (2026-02-12)
+This stage captures post-implementation fixes required after initial code review.
+
+### Critical Tasks
+1. Fix stale `seeds_frozen` after upload-import fast path:
+   - Problem:
+     - Upload-import currently writes `custom_seeds` via queryset `update(...)`,
+       bypassing model `save()` and `pre_save` signal (`freeze_tc_urls`).
+     - Result: `seeds_frozen` can stay stale and `get_seeds()` may return old data.
+   - Required implementation:
+     - In upload-import branch, always handle `seeds_frozen` explicitly so it can
+       never remain stale.
+     - Keep submit latency bounded: do not reintroduce expensive
+       `model.save()`/reversion path for large imports.
+     - Current chosen mitigation: invalidate cache (`seeds_frozen=""`) during
+       upload consume so runtime `get_seeds()` recomputes from current data.
+   - Required tests:
+     - Regression proving old frozen data is not returned after upload import.
+
+2. Remove partial-write risk on failed upload consume:
+   - Problem:
+     - M2M/attachment writes could happen before upload-id validation/decode,
+       allowing partial state changes on early-return errors.
+   - Required implementation:
+     - Validate/consume upload within transactional logic.
+     - Reorder side-effecting writes (`save_m2m`, attachments) to happen only
+       after upload has passed validation and decode checks.
+   - Required tests:
+     - Invalid upload id must not persist unrelated form edits or attachment
+       deletes.
+
+### High Tasks
+1. Make upload consume race-safe / one-time:
+   - Problem:
+     - Two near-simultaneous submits with same `upload_id` can race.
+   - Required implementation:
+     - Use transactional row locking (`select_for_update`) for upload consume.
+     - Keep delete-on-success semantics and session binding cleanup.
+   - Required tests:
+     - Reuse of consumed upload id is rejected and does not persist edits.
+
+2. Remove avoidable memory amplification during upload submit:
+   - Problem:
+     - Submit path decodes full file to text and then re-encodes full string
+       just for logging size.
+   - Required implementation:
+     - Do not call `len(new_custom_seeds.encode("utf-8"))` in timing logs.
+     - Use upload metadata (`offset`/stored size) for logged byte count.
+
+3. Harden backup file path generation:
+   - Problem:
+     - Backup filename used raw title characters; slash/path segments could lead
+       to writes outside intended backup directory.
+   - Required implementation:
+     - Sanitize title segment (slug-safe), enforce absolute-path containment
+       under `MEDIA_ROOT/SEEDS_BACKUP_DIR`, and write file with explicit UTF-8.
+   - Required tests:
+     - Backup filename/path sanitization regression.
+
+### Reversion Performance Guardrails
+- Keep `TopicCollection` reversion exclusions for large fields:
+  - `custom_seeds`
+  - `seeds_frozen`
+  - `last_changed`
+- Goal:
+  - avoid large `reversion_version` rows and submit-time overhead when importing
+    large custom seed files.
+- Verification:
+  - upload-import branch must avoid model save where large fields would be
+    serialized into reversion history.
+  - no stale seed behavior despite avoiding model save.
+
+## Post-Review Follow-up Stage (2026-02-12, Storage & Throughput)
+### Ingress policy decision (2026-02-12)
+- Decision:
+  - keep nginx `client_max_body_size` at **10MB** globally and for `/seeder/`.
+  - do not use `500MB` nginx body limits for chunked seed upload.
+- Context:
+  - chunk upload requests are sent in ~4MB parts; each request stays well below
+    10MB.
+  - raising nginx to 500MB for `/seeder/` increases unauthenticated edge abuse
+    surface without being required for chunked workflow correctness.
+- Timeouts for `/seeder/`:
+  - set broad request/response timeouts to **300s** for authenticated app area
+    (`client_body_timeout`, `proxy_connect_timeout`,
+    `proxy_send_timeout`, `proxy_read_timeout`).
+  - scope is path-level (`/seeder/`), not endpoint-specific.
+
+### Daily stale upload cleanup
+- Problem:
+  - Users may upload chunks and never submit the form.
+  - Temp files/rows then remain until explicitly removed and can exhaust disk.
+- Implemented approach:
+  - Daily cron job: `harvests.cron.cleanup_expired_chunked_uploads`.
+  - Deletes every `ChunkedUpload` older than `CHUNKED_UPLOAD_EXPIRATION_DELTA`
+    and removes associated temp files.
+  - Added to `CRONJOBS` in settings:
+    - `('5 1 * * *', 'harvests.cron.cleanup_expired_chunked_uploads')`
+- Expected behavior:
+  - stale partial/complete uploads are automatically reclaimed at least once/day.
+
+### Proactive cleanup on replacement upload
+- Problem:
+  - Uploading another file for the same topic/session could keep old upload
+    artifacts around until cron window.
+- Implemented approach:
+  - On first chunk of a new upload, remove older same-topic/same-user upload
+    bindings from session and delete corresponding upload artifacts.
+- Expected behavior:
+  - repeated re-uploads do not accumulate within active editing sessions.
+
+### Throughput optimization (submit path)
+- Implemented:
+  - Move UTF-8 decode outside the DB transaction and row-lock window.
+  - Keep transactional section focused on validation, update, and consume.
+  - Keep reversion-heavy model save path avoided for large imports.
+- Note:
+  - Writing 100MB text into DB is still inherently expensive; the optimization
+    removes avoidable lock/coordination overhead but does not remove database
+    I/O cost itself.
+
+### No-op save fast path for large collections (2026-02-12)
+- Problem:
+  - Editing a TC with very large `custom_seeds` could still take tens of
+    seconds even when no meaningful field was changed.
+- Root cause:
+  - no-upload edit branch still called `topic.save(...)` for large collections,
+    and `TopicCollection` pre-save seed-freezing logic could do expensive work.
+- Implemented approach:
+  - In `InternalCollectionEdit.form_valid`, detect "no real changes"
+    (`changed_data` + m2m/attachment deltas) and skip topic save entirely.
+  - For large-seed no-upload edits, save only actually changed concrete model
+    fields (`update_fields=changed_model_fields`) instead of broad field sets.
+  - In `freeze_tc_urls` pre-save signal, skip freeze recalculation when
+    `update_fields` does not include seed-related fields.
+  - Keep full freeze behavior for seed-related saves.
+- Expected behavior:
+  - Saving unchanged large TCs should return quickly (seconds, not tens of
+    seconds) because no large seed write/freeze path is executed.
 
 ## Prerequisites (must be done before coding)
 - Verify chunked upload migrations are applied:
@@ -109,8 +253,9 @@ Concrete implementation decision:
 
 ### 6) `Seeder/settings/env.py`
 Add/update env-driven settings:
+- `FILE_UPLOAD_MAX_MEMORY_SIZE = int(os.environ.get('FILE_UPLOAD_MAX_MEMORY_SIZE', 10485760))`
 - `CHUNKED_UPLOAD_MAX_BYTES = int(os.environ.get('CHUNKED_UPLOAD_MAX_BYTES', 524288000))`
-- `CHUNKED_UPLOAD_EXPIRATION_DELTA = int(os.environ.get('CHUNKED_UPLOAD_EXPIRATION_DELTA', 86400))`
+- `CHUNKED_UPLOAD_EXPIRATION_DELTA = int(os.environ.get('CHUNKED_UPLOAD_EXPIRATION_DELTA', 21600))`
 - `CHUNKED_UPLOAD_PATH = os.environ.get('CHUNKED_UPLOAD_PATH', 'chunked_uploads')`
 
 Lower non-file POST memory ceiling:
@@ -141,6 +286,12 @@ Note:
   - server-side ownership/context checks before consuming upload.
 - Lower `DATA_UPLOAD_MAX_MEMORY_SIZE` side effect:
   - if any endpoint depends on huge non-file POST bodies, that endpoint must get explicit handling or higher env value.
+- Slow submit after upload (large `custom_seeds`):
+  - avoid `model.save()` in the upload-consume branch because revision middleware
+    can serialize huge `custom_seeds` into `reversion_version` rows.
+  - persist edited scalar fields + `custom_seeds` via a single queryset
+    `update(...)` in that branch to keep submit latency bounded.
+  - keep `pair_custom_seeds()` out of the upload-import path.
 
 ## Testing Plan
 
@@ -170,3 +321,28 @@ Note:
 ## Rollout Notes
 - This plan is Django-centric and does not require global nginx/traefik changes.
 - If edge proxy adjustments are needed later, restrict them to the new upload endpoint paths only.
+
+## Implementation Notes (2026-02-12)
+- User-reported issue after initial rollout:
+  - In browser testing, clicking "Send" after a fully completed upload could
+    still take ~28s for a ~15MB file.
+- Investigation outcome:
+  - `pair_custom_seeds()` is not called in the upload-import branch.
+  - Main expensive work during submit is large `custom_seeds` persistence and
+    (previously) model `save()` side effects under `reversion` middleware.
+  - Some requests still had non-`custom_seeds` field changes (`date_from`)
+    in `form.changed_data`, which could trigger `topic.save(update_fields=...)`
+    and extra revision serialization cost.
+- Mitigation implemented:
+  - In upload-import branch, avoid model `save()` entirely.
+  - Persist both edited scalar fields and `custom_seeds` through a single
+    queryset `update(...)`, while keeping backup/replace semantics unchanged.
+  - Keep one-time upload consumption and context ownership checks unchanged.
+- Observability added:
+  - Upload-import submit logs detailed timings in
+    `Internal TC upload consume timings (...)` including:
+    `decode`, `backup`, `save`, `cleanup`, `total`.
+- Current known behavior:
+  - Submit path no longer runs seed pairing for upload-import.
+  - Remaining latency depends mostly on DB/storage performance for writing large
+    `custom_seeds` and backup file I/O.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ django-bootstrap3==11.0.0
 django-bower==5.1.0
 django-ckeditor==5.7.1
 django-crontab==0.7.1
+django-chunked-upload==2.0.0
 django-debug-toolbar==3.2.1
 django-extensions==2.1.6
 django-filter==2.4.0


### PR DESCRIPTION
@Santinni už jsem to všemožně testoval, pročítal kód a prošlo to asi 5 agentskými code reviews ale stejně na to pls alespoň letmo koukni, je to docela velká změna.

Tak obecně, jedná se o implementaci chunked uploadu na nahrávání velkých semínek, kde místo obrovského limitu na povolený upload size se nahrávají velké soubory (až do 500MB) po 4MB chuncích a až jakmile je celý soubor nahraný, tak se uloží do databáze.
Pokud se v TC custom_seeds nezmění, uloží se rychle, pokud se tam ale nahraje 100MB soubor, bude se to ukládat ~1min+ nebo to spadne na timeoutu, tam to prostě trvá kvůli zápisu do databáze.

Zároveň se nyní tyhle velké TC nezmrazují, protože by to v podstatě zdvojnásobilo množství dat v databázi. Dá se to nastavit, ale na rovinu by to chtělo krapet překopat tenhle upload na něco asynchroního, možná to bude potřeba i pro samotný upload pokud se budou opravdu uploadovat 100MB+ soubory.